### PR TITLE
FIX: Thread leak in pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinitypool"
 edition = "2021"
-version = "0.3.2"
+version = "0.3.1"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 description = "A Rust library for running blocking jobs on a dedicated thread pool with CPU core affinity"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "affinitypool"
 edition = "2021"
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 description = "A Rust library for running blocking jobs on a dedicated thread pool with CPU core affinity"


### PR DESCRIPTION
A thread in the thread pool captures Data that causes the channel to remain open indefinitely. This fix makes the thread to capture a weak reference to the Data, allowing the channel to be closed and the threads to be terminated.
