### PR TITLE
Correct FreeBSD Error CPU

### DIFF
--- a/src/affinity/freebsd.rs
+++ b/src/affinity/freebsd.rs
@@ -6,9 +6,9 @@ use libc::CPU_LEVEL_WHICH;
 use libc::CPU_SET;
 use libc::CPU_SETSIZE;
 use libc::CPU_WHICH_TID;
-use libc::cpu_set_t;
-use libc::sched_getaffinity;
-use libc::sched_setaffinity;
+use libc::cpuset_getaffinity;
+use libc::cpuset_setaffinity;
+use libc::cpuset_t;
 use std::mem;
 
 pub fn get_core_ids() -> Option<Vec<CoreId>> {


### PR DESCRIPTION
Compiling tokio-stream v0.1.18
Compiling affinitypool v0.4.0
Compiling object_store v0.13.1
error[E0432]: unresolved import libc::cpu_set_t
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:9:5
|
9 | use libc::cpu_set_t;
| ^^^^^^---------
| | |
| | help: a similar name exists in the module: cpuset_t
| no cpu_set_t in the root

error[E0425]: cannot find function cpuset_setaffinity in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:43:3
|
43 | cpuset_setaffinity(
| ^^^^^^^^^^^^^^^^^^
|
::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libc-0.2.182/src/unix/bsd/freebsdlike/freebsd/mod.rs:4623:5
|
4623 | / pub fn sched_setaffinity(
4624 | | pid: crate::pid_t,
4625 | | cpusetsz: size_t,
4626 | | cpuset: *const crate::cpuset_t,
4627 | | ) -> c_int;
| |_______________- similarly named function sched_setaffinity defined here
|
help: a function with a similar name exists
|
43 - cpuset_setaffinity(
43 + sched_setaffinity(
|
help: consider importing this function
|
3 + use libc::cpuset_setaffinity;
|

error[E0412]: cannot find type cpuset_t in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:47:19
|
47 | mem::size_of::<cpuset_t>(),
| ^^^^^^^^ not found in this scope
|
help: consider importing this struct
|
3 + use libc::cpuset_t;
|

error[E0412]: cannot find type cpuset_t in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:54:34
|
54 | fn get_affinity_mask() -> Option<cpuset_t> {
| ^^^^^^^^ not found in this scope
|
help: consider importing this struct
|
3 + use libc::cpuset_t;
|

error[E0425]: cannot find function cpuset_getaffinity in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:61:3
|
61 | cpuset_getaffinity(
| ^^^^^^^^^^^^^^^^^^
|
::: /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libc-0.2.182/src/unix/bsd/freebsdlike/freebsd/mod.rs:4618:5
|
4618 | / pub fn sched_getaffinity(
4619 | | pid: crate::pid_t,
4620 | | cpusetsz: size_t,
4621 | | cpuset: *mut crate::cpuset_t,
4622 | | ) -> c_int;
| |_______________- similarly named function sched_getaffinity defined here
|
help: a function with a similar name exists
|
61 - cpuset_getaffinity(
61 + sched_getaffinity(
|
help: consider importing this function
|
3 + use libc::cpuset_getaffinity;
|

error[E0412]: cannot find type cpuset_t in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:65:19
|
65 | mem::size_of::<cpuset_t>(),
| ^^^^^^^^ not found in this scope
|
help: consider importing this struct
|
3 + use libc::cpuset_t;
|

error[E0412]: cannot find type cpuset_t in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:77:21
|
77 | fn new_cpu_set() -> cpuset_t {
| ^^^^^^^^ not found in this scope
|
help: consider importing this struct
|
3 + use libc::cpuset_t;
|

error[E0412]: cannot find type cpuset_t in this scope
--> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/affinitypool-0.4.0/src/affinity/freebsd.rs:78:25
|
78 | unsafe { mem::zeroed::<cpuset_t>() }
| ^^^^^^^^ not found in this scope
|
help: consider importing this struct
|
3 + use libc::cpuset_t;
|

Some errors have detailed explanations: E0412, E0425, E0432.
For more information about an error, try rustc --explain E0412.
error: could not compile affinitypool (lib) due to 8 previous errors
warning: build failed, waiting for other jobs to finish...