### PR TITLE
Fix lost-wakeup race in park/unpark handshake

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use local::SpawnFuture;
 use parking_lot::Mutex;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 use task::OwnedTask;
 
 /// Maximum number of worker threads allowed in a thread pool.
@@ -132,6 +132,12 @@ impl Threadpool {
 		});
 		// Push the task to the global injector
 		self.data.injector.push(task);
+		// SeqCst fence pairs with the consumer's fence in the worker loop.
+		// Together they give a single total order over the producer's release
+		// on `injector` and the consumer's release on `parked_threads`, so the
+		// pop below either observes a worker that has registered itself, or
+		// that worker's re-check observes this push and self-rescues.
+		fence(Ordering::SeqCst);
 		// Wake up a parked worker thread
 		if let Some(thread) = self.data.parked_threads.pop() {
 			thread.unpark();
@@ -203,6 +209,11 @@ impl Threadpool {
 				retries += 1;
 				// Try stealing a batch of tasks from the global queue.
 				let result = data.injector.steal_batch_and_pop(local);
+				// SeqCst fence: same cross-variable handshake as `spawn`.
+				// Establishes a total order with a concurrent producer's fence
+				// so the opportunistic unpark either sees a parked worker or
+				// that worker observes the producer's injector push.
+				fence(Ordering::SeqCst);
 				// If there's work in the queue, wake a thread to help
 				if !data.injector.is_empty()
 					&& let Some(thread) = data.parked_threads.pop()
@@ -275,6 +286,13 @@ impl Threadpool {
 				} else {
 					// No work found, so register ourselves as parked
 					let _ = data.parked_threads.push(std::thread::current());
+					// SeqCst fence pairs with the producer's fence in
+					// `Threadpool::spawn`. Without it the re-check below may
+					// observe a pre-push state of `injector` even though the
+					// producer's `parked_threads.pop()` ran before our push
+					// — a lost wakeup. The fence forces a total order that
+					// rules this out.
+					fence(Ordering::SeqCst);
 					// Double-check for work after registering
 					if !data.injector.is_empty() {
 						// Work just arrived, try to wake a thread


### PR DESCRIPTION
## Summary

- Insert `fence(Ordering::SeqCst)` at three cross-variable handshake sites in [src/lib.rs](src/lib.rs) to close a latent lost-wakeup race between `Threadpool::spawn` and the worker park sequence.
- Affects the producer (`Threadpool::spawn`), the consumer registration in the `spin_up` worker loop, and the opportunistic unpark in `find_task`.
- Closes #21.

## Why

The producer's release on `injector` and the consumer's release on `parked_threads` live on different atomic objects, so plain release/acquire pairs cannot synchronise them. Without a fence, the consumer's re-check of `injector` can observe a pre-push state even when the producer's `parked_threads.pop()` already ran before the consumer's push — a classic Dekker's-algorithm lost wakeup. On x86 TSO masks it and CI passes; Miri (under `-Zmiri-tree-borrows`) deadlocks; ARM/RISC-V can manifest it on real hardware.

The `SeqCst` fences on each side establish a single total order over the four atomics, so either the producer's pop sees the consumer's registration or the consumer's re-check sees the producer's push. Tokio's `Notify` uses the same pattern.

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (34 integration tests pass, including `test_no_lost_wakeups_race_condition`)
- [x] `RUSTFLAGS="--cfg loom" LOOM_MAX_PREEMPTIONS=3 cargo test --test loom --release`
- [ ] Optional local: `MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-disable-isolation -Zmiri-ignore-leaks" cargo +nightly miri test --lib` (CI runs this automatically)

Re-enabling the scheduler integration tests under Miri is out of scope here — see the rationale in [.github/workflows/ci.yml:114-117](.github/workflows/ci.yml#L114).