### PR TITLE
Bump actions/checkout to v6 and criterion to 0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [stable]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -92,7 +92,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -126,7 +126,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libc = "^0.2.176"
 winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
 
 [target.'cfg(not(loom))'.dev-dependencies]
-criterion = { version = "0.7", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "time"] }
 trybuild = "1.0"
 


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from v4 to v6 across all six call sites in `.github/workflows/ci.yml`, preserving the existing SHA-pin + trailing `# vN` comment style (pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd`, the v6 tag).
- Bumps `criterion` dev-dependency from `0.7` to `0.8` in `Cargo.toml`.

Supersedes #15 (which only patched 4 of the now-6 checkout uses and predates the SHA-pin format) and #16 (which targeted the old `[dev-dependencies]` table before criterion was moved under `[target.'cfg(not(loom))'.dev-dependencies]`).

### criterion 0.8 compatibility

The two breaking changes in criterion 0.8 don't affect this crate:

- `async-std` support dropped — not used here.
- MSRV bumped to 1.86 — the crate is `edition = "2024"` (Rust ≥ 1.85) and CI runs `stable`, which is already past 1.86.

Benches already import `black_box` from `std::hint`, so the dropped `criterion::black_box` re-export is irrelevant.

## Test plan

- [x] `cargo bench --no-run` — benches compile against criterion 0.8
- [x] `cargo test` — 34 lib tests + 7 doctests pass locally
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] GitHub Actions green on `actions/checkout@v6`