### PR TITLE
Bump CI action pins and dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
         run: cargo build --verbose
@@ -64,7 +64,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -80,7 +80,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check benchmarks compile
         run: cargo bench --no-run
@@ -101,7 +101,7 @@ jobs:
           components: miri
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run Miri
         env:
@@ -132,7 +132,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run Loom models
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,21 +16,21 @@ resolver = "2"
 default = []
 
 [dependencies]
-arc-swap = "1.7"
+arc-swap = "1.9"
 crossbeam = "0.8.4"
 num_cpus = "1.17.0"
-parking_lot = "0.12.4"
-thiserror = "2.0.16"
+parking_lot = "0.12.5"
+thiserror = "2.0.18"
 
 [target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
-libc = "^0.2.176"
+libc = "^0.2.186"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
 
 [target.'cfg(not(loom))'.dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time"] }
 trybuild = "1.0"
 
 [target.'cfg(loom)'.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump `Swatinem/rust-cache` to `e18b4977` across all CI jobs
- Bump runtime/dev dependencies: `arc-swap` 1.7→1.9, `parking_lot` 0.12.4→0.12.5, `thiserror` 2.0.16→2.0.18, `libc` 0.2.176→0.2.186, `tokio` 1.47.1→1.52.3

## Notes
- `dtolnay/rust-toolchain` `# master` pin (`3c5f7ea…`) was already current; `# stable` pin left untouched as it tracks a different branch of the action.

## Test plan
- [ ] CI green across test / format / clippy / bench / miri / loom jobs