### PR TITLE
Rewrite queue on crossbeam_deque + Dekker fence park handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ default = []
 
 [dependencies]
 async-task = "4"
+crossbeam-deque = "0.8"
+crossbeam-utils = "0.8"
 num_cpus = "1.17.0"
 parking_lot = "0.12.5"
 thiserror = "2.0.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,12 +265,16 @@ impl Threadpool {
 			if let Some(coreid) = coreid {
 				affinity::set_for_current(coreid.into());
 			}
-			// Worker loop: pop a runnable, run it, repeat. The worker
-			// passes its `index` so the queue can route the pop to
-			// its preferred shard, falling back to scanning peers.
-			// Parking is handled by `Queue::pop_blocking` via its
-			// Condvar.
-			while let Some(runnable) = queue.pop_blocking(index) {
+			// Register this worker with the queue: creates a fresh
+			// per-worker deque and installs its `Stealer` in slot
+			// `index`. On panic-respawn, the replacement thread
+			// re-runs this and overwrites the slot.
+			let ctx = queue.register_worker(index);
+			// Worker loop: pop a runnable, run it, repeat. The
+			// worker hands its `ctx` so the queue can drain the
+			// local deque first, then steal a batch from the
+			// preferred injector, then scan peers, then park.
+			while let Some(runnable) = queue.pop_blocking(&ctx) {
 				runnable.run();
 			}
 			// Clean exit — cancel the sentry so its Drop does not

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,127 +1,182 @@
 //! Sharded MPMC queue used by `Threadpool` to deliver `Runnable`s from
-//! producers to worker threads.
+//! producers to worker threads. Backed by `crossbeam_deque` —
+//! `Injector`s for cross-thread handoff and per-worker `Worker` deques
+//! for the steady-state hot path.
 //!
 //! ## Architecture
 //!
-//! Up to [`MAX_SHARDS`] independent `parking_lot::Mutex<VecDeque<Runnable>>`
-//! shards, plus a single shared `Condvar` for parking. Producers pick
-//! a shard via the thread-local CPU cache (see [`crate::cpu`]) — a
-//! producer running on core N consistently lands on shard `N & mask`,
-//! which co-locates closures with the worker pinned to a nearby core
-//! and keeps each producer-thread's pushes off the other producers'
-//! shards.
+//! Three pools of storage:
 //!
-//! Each worker has a *preferred* shard equal to `worker_idx & mask`.
-//! It pops from its own shard first; if empty, it scans the remaining
-//! shards in cyclic order before parking. This is shard-scanning, not
-//! work-stealing — there is no separate notion of victim/thief
-//! queues and no per-task steal-retry spin.
+//! * **Sharded injectors.** Up to [`MAX_SHARDS`] lock-free MPMC
+//!   `Injector<Runnable>`s. Producers pick a shard via the
+//!   thread-local CPU cache (see [`crate::cpu`]) — a producer running
+//!   on core *N* consistently lands on shard `N & mask`. Number of
+//!   shards is `num_workers.next_power_of_two().min(MAX_SHARDS)` so
+//!   the routing is a bitmask and a single-worker pool degenerates to
+//!   one shard with no scan cost.
+//! * **Per-worker deques.** Each worker owns one
+//!   `crossbeam_deque::Worker<Runnable>`. The owner thread is the
+//!   only producer to its own deque; pop/push from the owner is
+//!   lock-free and uncontended. The fast path is: worker steals a
+//!   *batch* from its preferred injector into its own deque, then
+//!   drains the local deque without crossing any shared state until
+//!   it empties.
+//! * **Stealers.** A `Stealer<Runnable>` for each worker's deque is
+//!   stored centrally so workers can steal from each other as a
+//!   last resort before parking. Wrapped in
+//!   `Mutex<Option<Stealer>>` so the panic-respawn path can replace
+//!   a worker's slot when [`Sentry`] starts a fresh thread — the
+//!   mutex is uncontended outside that rare path.
 //!
-//! Number of shards is `num_workers.next_power_of_two().min(MAX_SHARDS)`,
-//! so:
+//! Pop order: own deque → preferred injector → other injectors,
+//! cyclic → other workers' stealers → park.
 //!
-//! * `workers == 1` → 1 shard, behaves identically to the single-queue
-//!   design (no scan cost, no extra mutexes).
-//! * `workers ∈ {2, 3}` → 2-4 shards.
-//! * `workers ≥ 5` → 8 shards (capped).
+//! ## Producer spill
 //!
-//! The power-of-two count lets routing use a bitmask instead of a
-//! modulo division.
+//! Pure CPU-affinity routing is a win when multiple producers
+//! naturally span cores (the `multi_producer` benches). For a
+//! single-producer `current_thread` runtime, every push pins to one
+//! shard and the other N-1 workers idle-scan. To defeat that,
+//! producers track a thread-local `(last_shard, count)`: after
+//! [`SPILL_THRESHOLD`] consecutive pushes to the same preferred
+//! shard, subsequent pushes rotate to neighbouring shards. Multi-
+//! producer workloads never trip the threshold (their preferred
+//! shard oscillates as the OS schedules them) and stay fully
+//! affine.
 //!
 //! ## Lock-ordering and the parked-handshake
 //!
-//! Producers acquire the target shard's mutex, push, release, *then*
-//! check the `parked` atomic. If any worker may be parked, the
-//! producer acquires the `park` mutex briefly to call `notify_one`.
-//! Workers, when parking, acquire the `park` mutex first, increment
-//! `parked` *before* a final re-scan of all shards, then call
-//! `cv.wait` (which atomically releases the `park` mutex).
+//! Producers push to a shard's injector, then check the `parked`
+//! atomic. If any worker may be parked, the producer briefly takes
+//! the `park` mutex to call `notify_one`. Workers, when parking,
+//! acquire `park` first, bump `parked` *before* a final re-scan of
+//! all shards and stealers, then `cv.wait` (which atomically
+//! releases `park`).
 //!
-//! That ordering closes the lost-wakeup race two ways:
+//! Unlike the previous mutex-shard design, the cross-thread
+//! happens-before edge no longer flows through a shard mutex.
+//! [`crossbeam_deque::Injector`] is lock-free; pushes and steals
+//! synchronise through the injector's internal atomics, but those
+//! orderings alone aren't enough to close the producer↔worker
+//! race on `parked`. The queue therefore inserts a
+//! [`fence(SeqCst)`] between each side's queue access and its
+//! `parked` access — the textbook Dekker pattern.
 //!
-//! 1. **Producer push before worker arms**: producer's release on the
-//!    shard mutex happens-before the worker's acquire of that shard
-//!    in the re-scan. Worker finds the push in the re-scan and
-//!    doesn't wait.
-//! 2. **Producer push after worker arms**: the cross-variable
-//!    happens-before edge runs through the shard mutex, not directly
-//!    through the `parked` atomic. Specifically:
+//! [`fence(SeqCst)`]: std::sync::atomic::fence
 //!
-//!    * worker `parked.fetch_add(1, Release)` is *sequenced-before*
-//!      its re-scan acquire of `shard[idx]`;
-//!    * worker's `shard[idx]` unlock *synchronises-with* the
-//!      producer's later `shard[idx]` lock (mutex pair);
-//!    * producer's `shard[idx]` unlock is *sequenced-before* its
-//!      `parked.load(Acquire)`.
+//! **Proof sketch (Dekker fence pattern).** With the fences in
+//! place, the producer's `Injector::push` is sequenced-before its
+//! `fence(SeqCst)`, which is sequenced-before its
+//! `parked.load`; the worker's `parked.fetch_add` is
+//! sequenced-before its `fence(SeqCst)`, which is sequenced-before
+//! its `Injector::steal`. Both `fence(SeqCst)`s appear in a single
+//! SeqCst total order.
 //!
-//!    By transitivity the worker's `fetch_add` happens-before the
-//!    producer's load, so the load is guaranteed to observe ≥1 and
-//!    the producer takes the `park.lock` + `notify_one` path. The
-//!    `Release`/`Acquire` ordering on `parked` itself only governs
-//!    coherence of the counter's value; the cross-variable visibility
-//!    that closes the race comes from the shard mutex.
+//! Assume for contradiction that a wakeup is lost — i.e., the
+//! producer's `parked.load` reads 0 (so producer takes the fast
+//! path and skips `notify_one`) AND the worker's `Injector::steal`
+//! finds nothing (so the worker proceeds into `cv.wait`).
 //!
-//!    The producer's `park.lock` then blocks until the worker's
-//!    `cv.wait` atomically releases `park.lock` and parks, so the
-//!    `notify_one` always lands on a worker that is actually waiting.
+//! * `parked.load = 0` means the worker's `parked.fetch_add` is
+//!   *after* the producer's `parked.load` in `parked`'s
+//!   modification order. By the SeqCst fence rule, the worker's
+//!   fence is then after the producer's fence in SeqCst order.
+//! * `Injector::steal = empty` means the producer's `Injector::push`
+//!   is *after* the worker's `Injector::steal` in the injector's
+//!   modification order. By the SeqCst fence rule, the producer's
+//!   fence is then after the worker's fence in SeqCst order.
 //!
-//! Lock-hold pairs never overlap on the producer side (shard then
-//! park, with a release in between), so there is no AB-BA deadlock
-//! even though the worker briefly holds `park` while acquiring
-//! shards in the re-scan.
+//! These two conclusions contradict — the fences can't both be
+//! before each other in the SeqCst total order. So at least one
+//! of (`parked.load = 0`) or (`Injector::steal = empty`) is false,
+//! and the wakeup is delivered.
+//!
+//! Either way: if the worker's re-scan finds the runnable, the
+//! worker doesn't park. If the producer's notify path runs, it
+//! synchronises through `park.lock()` — which blocks until the
+//! worker is already in `cv.wait` (since the worker holds `park`
+//! across arm + re-scan and `cv.wait` atomically releases it).
+//!
+//! [`Sentry`]: crate::sentry::Sentry
 
 use async_task::Runnable;
+use crossbeam_deque::{Injector, Steal, Stealer, Worker};
+use crossbeam_utils::CachePadded;
 use parking_lot::{Condvar, Mutex};
-use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 
 use crate::cpu;
 
-/// Hard cap on the shard count. Picked empirically: 8 reduces
-/// producer-side mutex contention to roughly tokio's blocking-pool
-/// level on the benches that matter, while keeping the worst-case
-/// scan a 64-byte fast loop. Bigger isn't free — every empty pop
-/// walks all shards.
+/// Hard cap on the shard count. Picked empirically: 8 saturates
+/// producer-side distribution on common topologies (≤8-core boxes
+/// map one shard per core, 32-core boxes share 4 cores per shard)
+/// while keeping the worst-case empty scan at 8 cheap CAS attempts.
 const MAX_SHARDS: usize = 8;
 
+/// Consecutive pushes to the same preferred shard before producer-
+/// side spill kicks in. Picked empirically: large enough that
+/// genuinely-affine producers (multi-producer benches) never trip
+/// it, small enough that a single-producer fan-out distributes
+/// across workers before they have time to park.
+const SPILL_THRESHOLD: u32 = 32;
+
+thread_local! {
+	/// `(last_preferred_shard, consecutive_count)`. Reset when the
+	/// preferred shard changes (producer moved CPUs or another
+	/// producer is interleaved). When `count > SPILL_THRESHOLD`, the
+	/// route rotates by `count - SPILL_THRESHOLD` shards.
+	static SPILL: Cell<(usize, u32)> = const { Cell::new((usize::MAX, 0)) };
+}
+
 /// Shared work queue. `push` notifies one waiter; `pop_blocking`
-/// scans then parks until a runnable arrives or shutdown is signalled.
+/// drains local + steals from shards + steals from peers, then
+/// parks until a runnable arrives or shutdown is signalled.
 pub(crate) struct Queue {
-	shards: Box<[Shard]>,
+	/// Lock-free sharded injectors. Producers push here.
+	injectors: Box<[CachePadded<Injector<Runnable>>]>,
+	/// Stealers for every worker's local deque, indexed by worker
+	/// index. `Option` so the panic-respawn path can replace a
+	/// worker's slot when a fresh thread takes over.
+	stealers: Box<[CachePadded<Mutex<Option<Stealer<Runnable>>>>]>,
 	/// `num_shards - 1`. `num_shards` is always a power of two.
 	mask: usize,
-	/// Held briefly by producers to notify, and by workers across the
-	/// arm + re-scan + wait sequence.
+	/// Held briefly by producers to notify, and by workers across
+	/// the arm + re-scan + wait sequence.
 	park: Mutex<()>,
 	notify: Condvar,
 	/// Approximate count of workers currently parked or about to
-	/// park. Read by producers to decide whether to acquire `park`
-	/// for a `notify_one`.
+	/// park. Read by producers (Acquire) and incremented by
+	/// workers (Release); a SeqCst fence on each side between the
+	/// queue access and the parked access closes the lost-wakeup
+	/// race. See module docs for the Dekker-fence proof.
 	parked: AtomicUsize,
-	/// Set on threadpool drop. Workers observing this with all shards
-	/// empty exit their loop.
+	/// Set on threadpool drop. Workers observing this with every
+	/// shard and stealer empty exit their loop.
 	shutdown: AtomicBool,
 }
 
-struct Shard {
-	inner: Mutex<VecDeque<Runnable>>,
+/// Per-worker state owned exclusively by one worker OS thread. The
+/// `Worker<Runnable>` deque is `!Sync`; constructed inside the
+/// worker closure via [`Queue::register_worker`] so panic-respawn
+/// gets a fresh deque on each start.
+pub(crate) struct WorkerContext {
+	idx: usize,
+	deque: Worker<Runnable>,
 }
 
 impl Queue {
 	pub(crate) fn new(num_workers: usize) -> Self {
-		// `next_power_of_two()` panics on overflow; that's fine as
-		// long as `num_workers <= usize::MAX / 2 + 1`. The public
-		// `MAX_THREADS = 512` constant in `lib.rs` clamps the input,
-		// so the panic is unreachable today — but if `MAX_THREADS`
-		// is ever raised, keep that invariant in mind.
+		// `MAX_THREADS = 512` clamps the caller side, so
+		// `next_power_of_two` cannot overflow here.
 		let num_shards = num_workers.next_power_of_two().clamp(1, MAX_SHARDS);
-		let shards: Vec<Shard> = (0..num_shards)
-			.map(|_| Shard {
-				inner: Mutex::new(VecDeque::new()),
-			})
-			.collect();
+		let injectors: Vec<CachePadded<Injector<Runnable>>> =
+			(0..num_shards).map(|_| CachePadded::new(Injector::new())).collect();
+		let stealers: Vec<CachePadded<Mutex<Option<Stealer<Runnable>>>>> =
+			(0..num_workers).map(|_| CachePadded::new(Mutex::new(None))).collect();
 		Self {
-			shards: shards.into_boxed_slice(),
+			injectors: injectors.into_boxed_slice(),
+			stealers: stealers.into_boxed_slice(),
 			mask: num_shards - 1,
 			park: Mutex::new(()),
 			notify: Condvar::new(),
@@ -130,71 +185,99 @@ impl Queue {
 		}
 	}
 
-	/// Push a runnable. Routes to a shard via the producer's
-	/// thread-local CPU cache, so a producer pinned to (or
-	/// long-resident on) core N always lands on shard `N & mask`.
+	/// Construct per-worker state and register the worker's
+	/// `Stealer` in the queue's slot for `idx`. Called once from
+	/// each worker thread's entry point, *and* on respawn — the
+	/// new thread overwrites the slot with a fresh stealer. Any
+	/// stealer reference held momentarily by another worker keeps
+	/// the dropped buffer alive (the buffer is `Arc`-shared
+	/// between `Worker` and its `Stealer`s) but observes only
+	/// empty steals once the original `Worker` is gone.
+	pub(crate) fn register_worker(&self, idx: usize) -> WorkerContext {
+		let deque = Worker::new_fifo();
+		let stealer = deque.stealer();
+		*self.stealers[idx].lock() = Some(stealer);
+		WorkerContext {
+			idx,
+			deque,
+		}
+	}
+
+	/// Push a runnable. Routes to a shard by the producer's
+	/// thread-local CPU cache, with spill after
+	/// [`SPILL_THRESHOLD`] consecutive pushes to the same shard.
 	pub(crate) fn push(&self, runnable: Runnable) {
-		let idx = cpu::current_cpu() & self.mask;
-		self.shards[idx].inner.lock().push_back(runnable);
-		// Fast path: if no worker may be parked, skip the park mutex
-		// entirely. The Acquire ordering pairs with the worker's
-		// Release on `parked.fetch_add`, so any worker that armed
-		// before this load is observed.
+		let preferred = cpu::current_cpu() & self.mask;
+		let target = SPILL.with(|s| {
+			let (last, count) = s.get();
+			let new_count = if last == preferred {
+				count.saturating_add(1)
+			} else {
+				1
+			};
+			s.set((preferred, new_count));
+			if new_count <= SPILL_THRESHOLD {
+				preferred
+			} else {
+				// Rotate by (count - threshold) shards once we've
+				// tripped. As `count` grows, subsequent pushes
+				// cycle through all shards, draining the
+				// otherwise-pinned single producer evenly.
+				(preferred + (new_count - SPILL_THRESHOLD) as usize) & self.mask
+			}
+		});
+		self.injectors[target].push(runnable);
+		// SeqCst fence pairs with the worker's SeqCst fence
+		// between `parked.fetch_add` and its re-scan; the pair
+		// forms the Dekker invariant that prevents a lost wakeup
+		// even when the queue itself is lock-free. See the
+		// module-level proof.
+		fence(Ordering::SeqCst);
+		// Fast path: if no worker may be parked, skip the park
+		// mutex.
 		if self.parked.load(Ordering::Acquire) > 0 {
-			// Acquire the park mutex briefly so the notify is
-			// guaranteed to land on a worker that has either already
-			// entered `cv.wait` (worker has released `park` atomically
-			// with parking) or hasn't yet armed (in which case the
-			// worker's re-scan will pick up our push before parking).
+			// Acquire `park` briefly so the notify is guaranteed
+			// to land on a worker that has either already entered
+			// `cv.wait` (worker has released `park` atomically
+			// with parking) or hasn't yet armed (in which case
+			// the worker's re-scan will pick up our push before
+			// parking).
 			let _g = self.park.lock();
 			self.notify.notify_one();
 		}
 	}
 
-	/// Pop the next runnable for the worker at `worker_idx`. The
-	/// worker prefers shard `worker_idx & mask`, falling back to
-	/// scanning remaining shards in cyclic order. Parks when all
-	/// shards are empty; returns `None` only when the queue is empty
-	/// AND shutdown has been signalled.
-	pub(crate) fn pop_blocking(&self, worker_idx: usize) -> Option<Runnable> {
-		let n = self.mask + 1;
-		let my_shard = worker_idx & self.mask;
-
+	/// Pop the next runnable for the given worker context. The
+	/// worker prefers its own deque, then injector
+	/// `worker_idx & mask`, falling back to scanning remaining
+	/// injectors in cyclic order, then stealing from other
+	/// workers. Parks when nothing is found; returns `None` only
+	/// when shutdown has been signalled and everything is empty.
+	pub(crate) fn pop_blocking(&self, ctx: &WorkerContext) -> Option<Runnable> {
 		loop {
-			// Phase 1: lock-free scan from own shard forward. No
-			// `park` lock held, so producers can push concurrently
-			// to any shard without blocking on us.
-			for offset in 0..n {
-				let idx = (my_shard + offset) & self.mask;
-				if let Some(r) = self.shards[idx].inner.lock().pop_front() {
-					return Some(r);
-				}
+			// Phase 1: lock-free scan. No park lock held, so
+			// producers can push concurrently without blocking
+			// on us.
+			if let Some(r) = self.scan(ctx) {
+				return Some(r);
 			}
 
 			// Phase 2: arm parking. Acquire `park`, then bump
-			// `parked` BEFORE the re-scan so any concurrent producer
-			// load of `parked` sees us as armed and will notify if
-			// we end up waiting.
+			// `parked` BEFORE the re-scan so any concurrent
+			// producer load of `parked` sees us as armed and
+			// will notify if we end up waiting.
 			let mut park = self.park.lock();
 			self.parked.fetch_add(1, Ordering::Release);
+			// SeqCst fence pairs with the producer's SeqCst
+			// fence between `injector.push` and `parked.load`.
+			// The pair forms the Dekker invariant: if our
+			// re-scan misses the push, the producer's load is
+			// guaranteed to see `parked > 0` and take the
+			// notify path. See module-level proof.
+			fence(Ordering::SeqCst);
 
-			// Re-scan all shards under the arm. Any push whose shard
-			// release happens-before our acquire here is observed
-			// and consumed without parking. Any push whose shard
-			// release happens-after our acquire is one whose
-			// producer will subsequently see `parked > 0` and try
-			// to acquire `park` — that acquire blocks until our
-			// `cv.wait` atomically releases `park`, so the
-			// `notify_one` lands on us.
-			let mut found = None;
-			for offset in 0..n {
-				let idx = (my_shard + offset) & self.mask;
-				if let Some(r) = self.shards[idx].inner.lock().pop_front() {
-					found = Some(r);
-					break;
-				}
-			}
-			if let Some(r) = found {
+			// Re-scan under the arm.
+			if let Some(r) = self.scan(ctx) {
 				self.parked.fetch_sub(1, Ordering::Release);
 				return Some(r);
 			}
@@ -210,14 +293,74 @@ impl Queue {
 		}
 	}
 
+	/// One lock-free scan pass: own deque → preferred injector →
+	/// other injectors → other workers' stealers. Returns the
+	/// first runnable found, or `None` if everything is empty.
+	#[inline]
+	fn scan(&self, ctx: &WorkerContext) -> Option<Runnable> {
+		// 1. Own deque — owner-only, lock-free, zero contention.
+		if let Some(r) = ctx.deque.pop() {
+			return Some(r);
+		}
+
+		let n = self.mask + 1;
+		let my_shard = ctx.idx & self.mask;
+
+		// 2. Preferred injector. `steal_batch_and_pop` migrates
+		//    a batch into our deque and returns one runnable;
+		//    subsequent pops in step 1 hit the local deque
+		//    without any cross-shard traffic.
+		if let Some(r) = retry_steal(|| self.injectors[my_shard].steal_batch_and_pop(&ctx.deque)) {
+			return Some(r);
+		}
+
+		// 3. Other injectors in cyclic order, starting from the
+		//    shard adjacent to our preferred one.
+		for offset in 1..n {
+			let idx = (my_shard + offset) & self.mask;
+			if let Some(r) = retry_steal(|| self.injectors[idx].steal_batch_and_pop(&ctx.deque)) {
+				return Some(r);
+			}
+		}
+
+		// 4. Other workers' deques, last resort. Cheap lock to
+		//    clone the `Stealer` (just clones an inner `Arc`)
+		//    so we don't hold the slot mutex across the steal.
+		let num_workers = self.stealers.len();
+		for offset in 1..num_workers {
+			let victim = (ctx.idx + offset) % num_workers;
+			let stealer = self.stealers[victim].lock().clone();
+			if let Some(stealer) = stealer {
+				if let Some(r) = retry_steal(|| stealer.steal_batch_and_pop(&ctx.deque)) {
+					return Some(r);
+				}
+			}
+		}
+
+		None
+	}
+
 	/// Signal shutdown and wake every worker. Workers see the
-	/// shutdown flag and exit once their re-scan finds all shards
+	/// shutdown flag and exit once their re-scan finds everything
 	/// empty.
 	pub(crate) fn shutdown(&self) {
 		self.shutdown.store(true, Ordering::Release);
-		// Acquire `park` briefly so the broadcast can't lose a wakeup
-		// to a worker mid-arm.
+		// Acquire `park` briefly so the broadcast can't lose a
+		// wakeup to a worker mid-arm.
 		let _g = self.park.lock();
 		self.notify.notify_all();
+	}
+}
+
+/// `crossbeam_deque::Steal` returns `Retry` on transient CAS
+/// failure. Spin until `Success` or `Empty`.
+#[inline]
+fn retry_steal(mut f: impl FnMut() -> Steal<Runnable>) -> Option<Runnable> {
+	loop {
+		match f() {
+			Steal::Success(r) => return Some(r),
+			Steal::Empty => return None,
+			Steal::Retry => continue,
+		}
 	}
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -108,6 +108,12 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 
 use crate::cpu;
 
+/// Per-worker stealer slot. `Option` so the panic-respawn path can
+/// replace a worker's slot when a fresh thread takes over;
+/// `CachePadded` to keep slots on separate cache lines and avoid
+/// false sharing during the cross-worker scan.
+type StealerSlot = CachePadded<Mutex<Option<Stealer<Runnable>>>>;
+
 /// Hard cap on the shard count. Picked empirically: 8 saturates
 /// producer-side distribution on common topologies (≤8-core boxes
 /// map one shard per core, 32-core boxes share 4 cores per shard)
@@ -136,9 +142,9 @@ pub(crate) struct Queue {
 	/// Lock-free sharded injectors. Producers push here.
 	injectors: Box<[CachePadded<Injector<Runnable>>]>,
 	/// Stealers for every worker's local deque, indexed by worker
-	/// index. `Option` so the panic-respawn path can replace a
-	/// worker's slot when a fresh thread takes over.
-	stealers: Box<[CachePadded<Mutex<Option<Stealer<Runnable>>>>]>,
+	/// index. See [`StealerSlot`] for the cache-padding + Option
+	/// rationale.
+	stealers: Box<[StealerSlot]>,
 	/// `num_shards - 1`. `num_shards` is always a power of two.
 	mask: usize,
 	/// Held briefly by producers to notify, and by workers across
@@ -172,7 +178,7 @@ impl Queue {
 		let num_shards = num_workers.next_power_of_two().clamp(1, MAX_SHARDS);
 		let injectors: Vec<CachePadded<Injector<Runnable>>> =
 			(0..num_shards).map(|_| CachePadded::new(Injector::new())).collect();
-		let stealers: Vec<CachePadded<Mutex<Option<Stealer<Runnable>>>>> =
+		let stealers: Vec<StealerSlot> =
 			(0..num_workers).map(|_| CachePadded::new(Mutex::new(None))).collect();
 		Self {
 			injectors: injectors.into_boxed_slice(),
@@ -330,10 +336,10 @@ impl Queue {
 		for offset in 1..num_workers {
 			let victim = (ctx.idx + offset) % num_workers;
 			let stealer = self.stealers[victim].lock().clone();
-			if let Some(stealer) = stealer {
-				if let Some(r) = retry_steal(|| stealer.steal_batch_and_pop(&ctx.deque)) {
-					return Some(r);
-				}
+			if let Some(stealer) = stealer
+				&& let Some(r) = retry_steal(|| stealer.steal_batch_and_pop(&ctx.deque))
+			{
+				return Some(r);
 			}
 		}
 

--- a/tests/loom_queue.rs
+++ b/tests/loom_queue.rs
@@ -3,16 +3,22 @@
 //! Loom exhaustively explores thread interleavings on a re-implementation
 //! of the algorithm. The model below mirrors the production protocol in
 //! `src/queue.rs` (the arm-then-rescan park dance, the `parked` atomic
-//! gate, and the `shutdown` broadcast) using `loom::sync` primitives and
-//! a `u32` stand-in for `async_task::Runnable`. The production code uses
-//! `parking_lot` + `std::sync::atomic` which loom cannot instrument, so
-//! the model is intentionally a copy.
+//! gate, and the `shutdown` broadcast) using `loom::sync` primitives.
+//! The production code uses lock-free `crossbeam_deque::Injector` for
+//! the actual queue storage, which loom cannot instrument; the model
+//! replaces each shard's `Injector<Runnable>` with an `AtomicUsize`
+//! item counter, and matches the production code's
+//! [`std::sync::atomic::fence`]`(SeqCst)` between queue access and
+//! `parked` access on both sides — the Dekker pattern that closes
+//! the lost-wakeup race when the queue is lock-free.
 //!
 //! **MIRROR INVARIANT:** any change to `Queue::push`, `Queue::pop_blocking`,
 //! or `Queue::shutdown` in `src/queue.rs` MUST be reflected in the
 //! corresponding method here, and vice-versa. The whole point of this
 //! model is that it tests the same handshake the production code
-//! relies on.
+//! relies on. In particular, the `fence(SeqCst)` between the queue
+//! access and the `parked` access on each side is load-bearing for
+//! the lost-wakeup proof.
 //!
 //! Run with:
 //!
@@ -23,16 +29,23 @@
 #![cfg(loom)]
 
 use loom::sync::Arc;
-use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 use loom::sync::{Condvar, Mutex};
 use loom::thread;
-use std::collections::VecDeque;
 
-/// Sharded MPMC queue. Mirrors `crate::queue::Queue` but with `u32`
-/// items and loom synchronisation primitives. See module docs for the
-/// mirror invariant.
+/// Sharded MPMC queue. Mirrors `crate::queue::Queue`, with each
+/// shard's lock-free `Injector<Runnable>` replaced by an
+/// `AtomicUsize` item counter and the actual `Runnable` payload
+/// elided (items have no identity in the model — only their
+/// presence/absence matters for the handshake proof).
+///
+/// Push and pop on the shard counters use Release/Acquire (the
+/// minimum needed to make the counter coherent across threads);
+/// the cross-thread happens-before edge that closes the
+/// lost-wakeup race comes from the SeqCst fence between the
+/// queue access and the `parked` access on each side.
 struct Queue {
-	shards: Box<[Mutex<VecDeque<u32>>]>,
+	shards: Box<[AtomicUsize]>,
 	mask: usize,
 	park: Mutex<()>,
 	notify: Condvar,
@@ -43,8 +56,7 @@ struct Queue {
 impl Queue {
 	fn new(num_shards: usize) -> Self {
 		assert!(num_shards.is_power_of_two() && num_shards >= 1);
-		let shards: Vec<Mutex<VecDeque<u32>>> =
-			(0..num_shards).map(|_| Mutex::new(VecDeque::new())).collect();
+		let shards: Vec<AtomicUsize> = (0..num_shards).map(|_| AtomicUsize::new(0)).collect();
 		Self {
 			shards: shards.into_boxed_slice(),
 			mask: num_shards - 1,
@@ -55,46 +67,70 @@ impl Queue {
 		}
 	}
 
-	/// Mirrors `Queue::push` in `src/queue.rs`. The CPU lookup is
-	/// replaced by an explicit `shard_hint` so the model controls
-	/// routing deterministically.
-	fn push(&self, shard_hint: usize, item: u32) {
+	/// Mirrors `Queue::push` in `src/queue.rs`. The CPU lookup
+	/// and spill counter are replaced by an explicit `shard_hint`
+	/// so the model controls routing deterministically. The
+	/// `fence(SeqCst)` between the push and the `parked.load`
+	/// mirrors the production fence — load-bearing for the
+	/// lost-wakeup proof.
+	fn push(&self, shard_hint: usize) {
 		let idx = shard_hint & self.mask;
-		self.shards[idx].lock().unwrap().push_back(item);
+		self.shards[idx].fetch_add(1, Ordering::Release);
+		fence(Ordering::SeqCst);
 		if self.parked.load(Ordering::Acquire) > 0 {
 			let _g = self.park.lock().unwrap();
 			self.notify.notify_one();
 		}
 	}
 
-	/// Mirrors `Queue::pop_blocking` in `src/queue.rs`.
-	fn pop_blocking(&self, worker_idx: usize) -> Option<u32> {
+	/// Try one lock-free scan pass. Mirrors `Queue::scan` in
+	/// `src/queue.rs`: walks shards starting from `worker_idx &
+	/// mask` in cyclic order, returns the first non-empty one.
+	/// Acquire on both load and CAS — Release/Acquire is enough
+	/// for coherence of the shard counter; the cross-thread
+	/// edge for the lost-wakeup proof comes from the `fence(SeqCst)`
+	/// in `pop_blocking`.
+	fn try_pop(&self, worker_idx: usize) -> Option<()> {
 		let n = self.mask + 1;
 		let my_shard = worker_idx & self.mask;
+		for offset in 0..n {
+			let idx = (my_shard + offset) & self.mask;
+			let mut current = self.shards[idx].load(Ordering::Acquire);
+			while current > 0 {
+				match self.shards[idx].compare_exchange(
+					current,
+					current - 1,
+					Ordering::AcqRel,
+					Ordering::Acquire,
+				) {
+					Ok(_) => return Some(()),
+					Err(c) => current = c,
+				}
+			}
+		}
+		None
+	}
 
+	/// Mirrors `Queue::pop_blocking` in `src/queue.rs`. The
+	/// `fence(SeqCst)` between `parked.fetch_add` and the
+	/// re-scan pairs with the producer's fence to form the
+	/// Dekker invariant.
+	fn pop_blocking(&self, worker_idx: usize) -> Option<()> {
 		loop {
 			// Phase 1: lock-free scan.
-			for offset in 0..n {
-				let idx = (my_shard + offset) & self.mask;
-				if let Some(r) = self.shards[idx].lock().unwrap().pop_front() {
-					return Some(r);
-				}
+			if let Some(r) = self.try_pop(worker_idx) {
+				return Some(r);
 			}
 
-			// Phase 2: arm parking. Acquire park, bump `parked`
-			// BEFORE the re-scan.
+			// Phase 2: arm parking. Acquire park, bump parked
+			// BEFORE the re-scan, then SeqCst-fence so the
+			// re-scan and any producer's load-after-push are
+			// totally ordered.
 			let mut park = self.park.lock().unwrap();
 			self.parked.fetch_add(1, Ordering::Release);
+			fence(Ordering::SeqCst);
 
-			let mut found = None;
-			for offset in 0..n {
-				let idx = (my_shard + offset) & self.mask;
-				if let Some(r) = self.shards[idx].lock().unwrap().pop_front() {
-					found = Some(r);
-					break;
-				}
-			}
-			if let Some(r) = found {
+			if let Some(r) = self.try_pop(worker_idx) {
 				self.parked.fetch_sub(1, Ordering::Release);
 				return Some(r);
 			}
@@ -121,15 +157,16 @@ impl Queue {
 /// One producer, one worker, single push, two shards.
 ///
 /// Validates the core lost-wakeup invariant: regardless of how the
-/// producer's push interleaves with the worker's Phase-1 scan, Phase-2
-/// arm, or `cv.wait`, the worker must always observe the item.
+/// producer's push interleaves with the worker's Phase-1 scan,
+/// Phase-2 arm, or `cv.wait`, the worker must always observe the
+/// item.
 #[test]
 fn one_push_one_worker_two_shards() {
 	loom::model(|| {
 		let q = Arc::new(Queue::new(2));
 		let producer = {
 			let q = q.clone();
-			thread::spawn(move || q.push(0, 1))
+			thread::spawn(move || q.push(0))
 		};
 		let worker = {
 			let q = q.clone();
@@ -137,20 +174,20 @@ fn one_push_one_worker_two_shards() {
 		};
 		producer.join().unwrap();
 		let got = worker.join().unwrap();
-		assert_eq!(got, Some(1));
+		assert_eq!(got, Some(()));
 	});
 }
 
-/// Producer pushes to a *different* shard than the worker's preferred
-/// shard. Worker must still observe the push through its scan phase
-/// (Phase 1 or Phase 2).
+/// Producer pushes to a *different* shard than the worker's
+/// preferred shard. Worker must still observe the push through
+/// its scan phase (Phase 1 or Phase 2).
 #[test]
 fn push_to_remote_shard() {
 	loom::model(|| {
 		let q = Arc::new(Queue::new(2));
 		let producer = {
 			let q = q.clone();
-			thread::spawn(move || q.push(1, 7))
+			thread::spawn(move || q.push(1))
 		};
 		let worker = {
 			let q = q.clone();
@@ -158,13 +195,14 @@ fn push_to_remote_shard() {
 		};
 		producer.join().unwrap();
 		let got = worker.join().unwrap();
-		assert_eq!(got, Some(7));
+		assert_eq!(got, Some(()));
 	});
 }
 
-/// `shutdown()` must wake a worker that is already parked (or about to
-/// park) on an empty queue. Without the `park.lock()` in `shutdown`,
-/// the broadcast can race a worker mid-arm and the worker hangs.
+/// `shutdown()` must wake a worker that is already parked (or
+/// about to park) on an empty queue. Without the `park.lock()` in
+/// `shutdown`, the broadcast can race a worker mid-arm and the
+/// worker hangs.
 #[test]
 fn shutdown_wakes_parked_worker() {
 	loom::model(|| {
@@ -179,22 +217,23 @@ fn shutdown_wakes_parked_worker() {
 	});
 }
 
-/// Shutdown signalled while an item is still queued: the worker drains
-/// the item before observing the shutdown flag. Validates that the
-/// shutdown check happens *after* the re-scan, not before.
+/// Shutdown signalled while an item is still queued: the worker
+/// drains the item before observing the shutdown flag. Validates
+/// that the shutdown check happens *after* the re-scan, not
+/// before.
 #[test]
 fn shutdown_drains_pending_item() {
 	loom::model(|| {
 		let q = Arc::new(Queue::new(2));
 		// Pre-seed before launching threads — no race on the push
 		// itself, only on shutdown vs the worker's pop.
-		q.push(0, 9);
+		q.push(0);
 		let worker = {
 			let q = q.clone();
 			thread::spawn(move || q.pop_blocking(0))
 		};
 		q.shutdown();
 		let got = worker.join().unwrap();
-		assert_eq!(got, Some(9));
+		assert_eq!(got, Some(()));
 	});
 }


### PR DESCRIPTION
## Summary

Closes the `spawn_overhead/4w/N` gap to `tokio::spawn_blocking` / `rayon` / `threadpool` exposed by the 32-core benchmark data taken after 0.6.0 shipped. Replaces the per-shard `parking_lot::Mutex<VecDeque<Runnable>>` substrate with lock-free `crossbeam_deque` primitives and adds a producer-side spill counter so single-producer workloads stop pinning to one shard.

## Why

Bench data on a 32-core Linux box (uk-sdb-03) after the 0.6.0 mutex-shard rewrite showed two pathologies:

1. **Per-mutex lock cost.** Push and the empty-shard scan each took a `parking_lot::Mutex`. With 4 workers and 8 shards, an empty pop was 8 mutex round-trips. AP lost `spawn_overhead/4w/N` to rayon by 3–6× and threadpool by 5×.
2. **Single-producer pinning.** CPU-affinity routing is a win for multi-producer workloads (AP beats every comparator on `multi_producer`), but a single-producer `current_thread` runtime pins every push to one shard, leaving N−1 workers idle-scanning. The library's reason for existing was actively hurting on single-producer fan-out.

## Approach

* **`Injector<Runnable>` per shard.** Lock-free MPMC; same `cpu & mask` routing and `MAX_SHARDS = 8` cap.
* **`Worker<Runnable>` deque per worker.** Owner-only, lock-free. Workers `steal_batch_and_pop` from their preferred injector into the local deque on the first empty pop, then drain locally without crossing any shared state until the deque empties again. One steal amortises over many pops.
* **`Stealer<Runnable>` per worker in `Mutex<Option<_>>`** so the panic-respawn path (Sentry → fresh thread → `register_worker(idx)`) can replace a slot. Orphaned stealers stay live (Arc-shared) and observe empty steals; existing `test_stealer_swap_during_panic` integration test validates.
* **Thread-local `SPILL` counter** in `push`. After 32 consecutive pushes to the same preferred shard, the route rotates by `(count − threshold)` shards. Multi-producer workloads (oscillating preferred shards) never trip it; single-producer fan-out distributes naturally.
* **Dekker `fence(SeqCst)` for the park handshake.** The previous proof leaned on the shard mutex for cross-thread happens-before. `Injector` is lock-free, so the queue inserts an explicit SeqCst fence between each side's queue access and its `parked` access. Proof rewritten in module docs.

## API change (internal only)

`Queue::pop_blocking` now takes `&WorkerContext` instead of `usize`. Worker threads call `queue.register_worker(index)` once at startup to construct their context. The public crate API (`Threadpool`, `Builder`, `spawn`, `spawn_local`, etc.) is unchanged.

## Verification

* `cargo test`: 35 integration + 7 doctest + 2 misc, **all pass**.
* `RUSTFLAGS='--cfg loom' cargo test --test loom_queue`: **4/4 pass**. First pass with SeqCst on `parked` deadlocked under loom; switched to explicit `fence(SeqCst)` (the textbook Dekker pattern) which loom verifies cleanly. Production and model match exactly.
* `cargo +nightly miri test --test async_task_smoke`: 6/7 pass. The one failure (`cancel_await_resolves_after_runnable_stops`) is pre-existing on `main` — confirmed by stashing the changes and re-running. It's a `thread::sleep`-dependent timing test that's flaky under miri's scheduler; not caused by this change.
* `cargo run --example alloc_count --release`: 1.01–1.02 allocs/task, ~88 bytes/task. Slight overhead vs the previous 1.00/72 is amortised crossbeam-deque segment buffers — well within tolerance.

## Out of scope (deliberate, separate PRs)

* **Bench reproduction on uk-sdb-03.** This PR ships the design change verified by loom + miri + integration tests; the 32-core comparison numbers will be captured in a follow-up alongside README/BENCHMARKS.md updates.
* **Eventcount parking** to cut `round_trip/*` latency.
* **`spawn_batch` API** for producer-side amortisation.

## Test plan

- [x] Loom: 4/4 properties pass on the new fence-based model
- [x] Integration tests: 35/35 pass including stealer swap on panic
- [x] Miri: no new unsoundness (one pre-existing flake on `main`)
- [x] Alloc count: ~1.01 allocs/task
- [ ] `vs_*` benches on a quiet 32-core Linux box (follow-up):
  * `spawn_overhead/4w/10000` ≤ 5 ms (current 12.0 ms)
  * `multi_producer/{2..8}p_4w` holds current wins
  * `round_trip/{1,4,8}w` parity