### PR TITLE
queue: incremental wins — mask==0, inline, ArcSwap stealers, self-spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Behavioural notes
+
+- **Worker self-spawn fast path.** When a closure running on a
+  worker thread calls `pool.spawn(...)`, the new task is pushed
+  directly into that worker's own local deque instead of routing
+  through the shared injector. The producer (this thread) is also
+  the consumer, so no cross-thread wake is issued — *other workers
+  currently parked stay parked*. This is intentional and almost
+  always what you want (it saves the wake roundtrip), but a
+  workload that fans out **only** via self-spawn cascades, with no
+  external producer to wake parked peers, will serialise on the
+  spawning worker until something else wakes them. The spawning
+  worker's local deque is still a stealer target, so peers that
+  wake on a later foreign push will recover the imbalance.
+
 ## 0.6.0 — 2026-05-24 — async-task rewrite + sharded queue
 
 A major internal rewrite that closes the 8-15× performance gap versus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "2"
 default = []
 
 [dependencies]
+arc-swap = "1.7"
 async-task = "4"
 crossbeam-deque = "0.8"
 crossbeam-utils = "0.8"

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ Shard count rules of thumb:
 | 2–3 | 2–4 |
 | ≥ 5 | 8 (capped) |
 
+### Behaviour notes
+
+**Worker self-spawn fast path.** When a closure running on a worker thread calls `pool.spawn(...)`, the new task is pushed directly into that worker's own local deque instead of routing through the shared sharded queue. The producer (this thread) is also the consumer, so no cross-thread wake is issued — *other workers currently parked stay parked*. This is intentional and saves a wake roundtrip, but a workload that fans out **only** via self-spawn cascades with no external producer to wake parked peers will serialise on the spawning worker until something else wakes them. The spawning worker's local deque is still a stealer target, so peers that wake on a later foreign push will recover the imbalance.
+
 #### Original
 
 This code is heavily inspired by [threadpool](https://crates.io/crates/threadpool), with the CPU-based affinity code forked originally from [core-affinity](https://crates.io/crates/core_affinity). Both are licensed under the Apache License 2.0 and MIT licenses.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,3 +317,53 @@ impl Drop for Threadpool {
 		self.data.thread_count.store(0, Ordering::Relaxed);
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::sync::mpsc;
+	use std::time::Duration;
+
+	/// Confirms the worker self-spawn fast path actually engaged
+	/// (not just that the work eventually ran via the fallback).
+	/// Reads the test-only `Queue::foreign_pushes` counter: every
+	/// `Threadpool::spawn` that takes the foreign-producer path
+	/// bumps it. A self-spawn from inside a worker closure should
+	/// NOT bump it.
+	#[tokio::test]
+	async fn self_spawn_does_not_increment_foreign_push_counter() {
+		let pool = Arc::new(Threadpool::new(4));
+
+		// Drain any startup noise from constructing the pool.
+		pool.data.queue.foreign_pushes.store(0, Ordering::Relaxed);
+
+		let pool_clone = pool.clone();
+		let (tx, rx) = mpsc::channel();
+
+		// The outer spawn is a foreign push (we're calling from
+		// the tokio runtime thread, not a worker). It bumps the
+		// counter by 1.
+		pool.spawn(move || {
+			// We're now on a worker thread for `pool`. The
+			// self-spawn fast path should engage: this push goes
+			// directly into the worker's local deque, NOT through
+			// the foreign-producer path.
+			let inner = pool_clone.spawn(move || tx.send(()).unwrap());
+			std::mem::forget(inner);
+		})
+		.await;
+
+		// Wait for the inner closure to run on the worker (via
+		// the local deque, not via cross-worker steal).
+		rx.recv_timeout(Duration::from_secs(5)).expect("inner closure didn't run");
+
+		// Only the outer spawn should have hit the foreign-push
+		// path; the inner self-spawn must have taken the fast
+		// path.
+		let foreign_count = pool.data.queue.foreign_pushes.load(Ordering::Relaxed);
+		assert_eq!(
+			foreign_count, 1,
+			"expected exactly one foreign push (the outer); got {foreign_count} — self-spawn fast path didn't engage"
+		);
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,13 @@ impl Threadpool {
 			// `index`. On panic-respawn, the replacement thread
 			// re-runs this and overwrites the slot.
 			let ctx = queue.register_worker(index);
+			// Mark this thread as a worker for `queue` so that
+			// `pool.spawn(...)` calls from inside `runnable.run()`
+			// route directly into the local deque, skipping the
+			// shared injector. Dropped at the end of this scope,
+			// clearing the thread-local registration before the
+			// `WorkerContext` itself goes out of scope.
+			let _worker_scope = queue.enter_worker_scope(&ctx);
 			// Worker loop: pop a runnable, run it, repeat. The
 			// worker hands its `ctx` so the queue can drain the
 			// local deque first, then steal a batch from the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,8 +369,9 @@ mod tests {
 		// it. The inner closure runs on the worker (via the local
 		// deque if the fast path engaged), and awaiting yields
 		// its return value.
-		let inner =
-			handle_rx.recv_timeout(Duration::from_secs(5)).expect("worker didn't send inner handle");
+		let inner = handle_rx
+			.recv_timeout(Duration::from_secs(5))
+			.expect("worker didn't send inner handle");
 		let v = inner.await;
 		assert_eq!(v, 42);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,7 @@ impl Drop for Threadpool {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::pin::Pin;
 	use std::sync::mpsc;
 	use std::time::Duration;
 
@@ -330,15 +331,26 @@ mod tests {
 	/// `Threadpool::spawn` that takes the foreign-producer path
 	/// bumps it. A self-spawn from inside a worker closure should
 	/// NOT bump it.
+	///
+	/// Uses a 1-worker pool so the foreign-push branch hits the
+	/// `mask == 0` fast path and never calls `cpu::current_cpu()`
+	/// (`sched_getcpu` isn't supported under miri).
+	///
+	/// The inner `JoinHandle` is sent to the test thread via an
+	/// mpsc channel and awaited there, instead of `mem::forget`-ed
+	/// — keeps the test leak-free under miri while still letting
+	/// the inner closure run to completion on the worker.
 	#[tokio::test]
 	async fn self_spawn_does_not_increment_foreign_push_counter() {
-		let pool = Arc::new(Threadpool::new(4));
+		type InnerFuture = Pin<Box<dyn Future<Output = u32> + Send + 'static>>;
+
+		let pool = Arc::new(Threadpool::new(1));
 
 		// Drain any startup noise from constructing the pool.
 		pool.data.queue.foreign_pushes.store(0, Ordering::Relaxed);
 
 		let pool_clone = pool.clone();
-		let (tx, rx) = mpsc::channel();
+		let (handle_tx, handle_rx) = mpsc::channel::<InnerFuture>();
 
 		// The outer spawn is a foreign push (we're calling from
 		// the tokio runtime thread, not a worker). It bumps the
@@ -348,14 +360,19 @@ mod tests {
 			// self-spawn fast path should engage: this push goes
 			// directly into the worker's local deque, NOT through
 			// the foreign-producer path.
-			let inner = pool_clone.spawn(move || tx.send(()).unwrap());
-			std::mem::forget(inner);
+			let inner: InnerFuture = Box::pin(pool_clone.spawn(|| 42u32));
+			handle_tx.send(inner).unwrap();
 		})
 		.await;
 
-		// Wait for the inner closure to run on the worker (via
-		// the local deque, not via cross-worker steal).
-		rx.recv_timeout(Duration::from_secs(5)).expect("inner closure didn't run");
+		// Receive the inner future on the test thread and await
+		// it. The inner closure runs on the worker (via the local
+		// deque if the fast path engaged), and awaiting yields
+		// its return value.
+		let inner =
+			handle_rx.recv_timeout(Duration::from_secs(5)).expect("worker didn't send inner handle");
+		let v = inner.await;
+		assert_eq!(v, 42);
 
 		// Only the outer spawn should have hit the foreign-push
 		// path; the inner self-spawn must have taken the fast

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -99,20 +99,23 @@
 //!
 //! [`Sentry`]: crate::sentry::Sentry
 
+use arc_swap::ArcSwapOption;
 use async_task::Runnable;
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use crossbeam_utils::CachePadded;
 use parking_lot::{Condvar, Mutex};
 use std::cell::Cell;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 
 use crate::cpu;
 
-/// Per-worker stealer slot. `Option` so the panic-respawn path can
-/// replace a worker's slot when a fresh thread takes over;
-/// `CachePadded` to keep slots on separate cache lines and avoid
-/// false sharing during the cross-worker scan.
-type StealerSlot = CachePadded<Mutex<Option<Stealer<Runnable>>>>;
+/// Per-worker stealer slot. `ArcSwapOption` so the steal-scan path
+/// can read with a single atomic load (no mutex acquire), while
+/// the panic-respawn path can still atomically replace a worker's
+/// slot when a fresh thread takes over. `CachePadded` to keep slots
+/// on separate cache lines and avoid false sharing during scans.
+type StealerSlot = CachePadded<ArcSwapOption<Stealer<Runnable>>>;
 
 /// Hard cap on the shard count. Picked empirically: 8 saturates
 /// producer-side distribution on common topologies (≤8-core boxes
@@ -179,7 +182,7 @@ impl Queue {
 		let injectors: Vec<CachePadded<Injector<Runnable>>> =
 			(0..num_shards).map(|_| CachePadded::new(Injector::new())).collect();
 		let stealers: Vec<StealerSlot> =
-			(0..num_workers).map(|_| CachePadded::new(Mutex::new(None))).collect();
+			(0..num_workers).map(|_| CachePadded::new(ArcSwapOption::empty())).collect();
 		Self {
 			injectors: injectors.into_boxed_slice(),
 			stealers: stealers.into_boxed_slice(),
@@ -202,7 +205,7 @@ impl Queue {
 	pub(crate) fn register_worker(&self, idx: usize) -> WorkerContext {
 		let deque = Worker::new_fifo();
 		let stealer = deque.stealer();
-		*self.stealers[idx].lock() = Some(stealer);
+		self.stealers[idx].store(Some(Arc::new(stealer)));
 		WorkerContext {
 			idx,
 			deque,
@@ -341,14 +344,13 @@ impl Queue {
 			}
 		}
 
-		// 4. Other workers' deques, last resort. Cheap lock to
-		//    clone the `Stealer` (just clones an inner `Arc`)
-		//    so we don't hold the slot mutex across the steal.
+		// 4. Other workers' deques, last resort. Lock-free
+		//    `ArcSwapOption::load` returns an `Arc<Stealer>` we
+		//    can steal through without any per-slot mutex.
 		let num_workers = self.stealers.len();
 		for offset in 1..num_workers {
 			let victim = (ctx.idx + offset) % num_workers;
-			let stealer = self.stealers[victim].lock().clone();
-			if let Some(stealer) = stealer
+			if let Some(stealer) = self.stealers[victim].load_full()
 				&& let Some(r) = retry_steal(|| stealer.steal_batch_and_pop(&ctx.deque))
 			{
 				return Some(r);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -212,27 +212,38 @@ impl Queue {
 	/// Push a runnable. Routes to a shard by the producer's
 	/// thread-local CPU cache, with spill after
 	/// [`SPILL_THRESHOLD`] consecutive pushes to the same shard.
+	#[inline]
 	pub(crate) fn push(&self, runnable: Runnable) {
-		let preferred = cpu::current_cpu() & self.mask;
-		let target = SPILL.with(|s| {
-			let (last, count) = s.get();
-			let new_count = if last == preferred {
-				count.saturating_add(1)
-			} else {
-				1
-			};
-			s.set((preferred, new_count));
-			if new_count <= SPILL_THRESHOLD {
-				preferred
-			} else {
-				// Rotate by (count - threshold) shards once we've
-				// tripped. As `count` grows, subsequent pushes
-				// cycle through all shards, draining the
-				// otherwise-pinned single producer evenly.
-				(preferred + (new_count - SPILL_THRESHOLD) as usize) & self.mask
-			}
-		});
-		self.injectors[target].push(runnable);
+		// Single-shard fast path: skip the CPU lookup, SPILL
+		// thread-local, and bitmask arithmetic — they're all
+		// dead work when `mask == 0` (which corresponds to a
+		// 1-worker pool). The fence + park-check below still
+		// run; producer↔worker synchronisation is independent of
+		// shard count.
+		if self.mask == 0 {
+			self.injectors[0].push(runnable);
+		} else {
+			let preferred = cpu::current_cpu() & self.mask;
+			let target = SPILL.with(|s| {
+				let (last, count) = s.get();
+				let new_count = if last == preferred {
+					count.saturating_add(1)
+				} else {
+					1
+				};
+				s.set((preferred, new_count));
+				if new_count <= SPILL_THRESHOLD {
+					preferred
+				} else {
+					// Rotate by (count - threshold) shards once
+					// we've tripped. As `count` grows, subsequent
+					// pushes cycle through all shards, draining
+					// the otherwise-pinned single producer evenly.
+					(preferred + (new_count - SPILL_THRESHOLD) as usize) & self.mask
+				}
+			});
+			self.injectors[target].push(runnable);
+		}
 		// SeqCst fence pairs with the worker's SeqCst fence
 		// between `parked.fetch_add` and its re-scan; the pair
 		// forms the Dekker invariant that prevents a lost wakeup
@@ -259,6 +270,7 @@ impl Queue {
 	/// injectors in cyclic order, then stealing from other
 	/// workers. Parks when nothing is found; returns `None` only
 	/// when shutdown has been signalled and everything is empty.
+	#[inline]
 	pub(crate) fn pop_blocking(&self, ctx: &WorkerContext) -> Option<Runnable> {
 		loop {
 			// Phase 1: lock-free scan. No park lock held, so

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -105,6 +105,8 @@ use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use crossbeam_utils::CachePadded;
 use parking_lot::{Condvar, Mutex};
 use std::cell::Cell;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, fence};
 
@@ -136,7 +138,29 @@ thread_local! {
 	/// producer is interleaved). When `count > SPILL_THRESHOLD`, the
 	/// route rotates by `count - SPILL_THRESHOLD` shards.
 	static SPILL: Cell<(usize, u32)> = const { Cell::new((usize::MAX, 0)) };
+
+	/// When this thread is a worker for some `Queue`, holds raw
+	/// pointers to that queue and the worker's local deque. Set
+	/// by [`Queue::enter_worker_scope`] and cleared when the
+	/// returned [`WorkerScope`] is dropped. [`Queue::push`] reads
+	/// this to fast-path through the worker's own deque when the
+	/// producer is itself a worker for this queue.
+	static CURRENT_WORKER: Cell<Option<WorkerHandle>> = const { Cell::new(None) };
 }
+
+/// Pointer pair stashed in [`CURRENT_WORKER`] for the duration of
+/// a worker thread's scope. Both pointers are valid only while
+/// the corresponding [`WorkerScope`] is alive.
+#[derive(Clone, Copy)]
+struct WorkerHandle {
+	queue: NonNull<Queue>,
+	deque: NonNull<Worker<Runnable>>,
+}
+
+// `WorkerHandle` holds raw pointers and is only ever read on the
+// thread that wrote it (the worker thread itself), so `Send` /
+// `Sync` aren't needed and aren't requested. The thread-local
+// machinery handles per-thread isolation.
 
 /// Shared work queue. `push` notifies one waiter; `pop_blocking`
 /// drains local + steals from shards + steals from peers, then
@@ -172,6 +196,22 @@ pub(crate) struct Queue {
 pub(crate) struct WorkerContext {
 	idx: usize,
 	deque: Worker<Runnable>,
+}
+
+/// RAII guard returned by [`Queue::enter_worker_scope`]. While
+/// alive, the calling thread's [`CURRENT_WORKER`] holds a handle
+/// to the queue + the worker's local deque so [`Queue::push`]
+/// from the same thread can fast-path. On drop, clears the
+/// thread-local so any later `push` from this thread falls back
+/// to the foreign-producer path.
+pub(crate) struct WorkerScope<'a> {
+	_phantom: PhantomData<&'a ()>,
+}
+
+impl Drop for WorkerScope<'_> {
+	fn drop(&mut self) {
+		CURRENT_WORKER.with(|w| w.set(None));
+	}
 }
 
 impl Queue {
@@ -212,11 +252,80 @@ impl Queue {
 		}
 	}
 
+	/// Register the calling thread as the active worker for this
+	/// queue with the given context. Subsequent [`Queue::push`]
+	/// calls from this thread that target this queue will route
+	/// directly into the context's local deque, skipping the
+	/// shared injector and the cross-thread wake-up handshake.
+	/// The returned [`WorkerScope`] clears the thread-local
+	/// registration on drop.
+	///
+	/// Must be called from the worker thread *after*
+	/// [`Self::register_worker`], with the context held on the
+	/// same stack frame for the scope's lifetime. The
+	/// `'a` borrow on both `&self` and `ctx` makes it impossible
+	/// for the scope to outlive either.
+	pub(crate) fn enter_worker_scope<'a>(&'a self, ctx: &'a WorkerContext) -> WorkerScope<'a> {
+		// `ctx.deque` is held on the worker thread's stack until
+		// after the scope is dropped, so its address is stable
+		// for the scope's lifetime.
+		CURRENT_WORKER.with(|w| {
+			w.set(Some(WorkerHandle {
+				queue: NonNull::from(self),
+				deque: NonNull::from(&ctx.deque),
+			}))
+		});
+		WorkerScope {
+			_phantom: PhantomData,
+		}
+	}
+
 	/// Push a runnable. Routes to a shard by the producer's
 	/// thread-local CPU cache, with spill after
 	/// [`SPILL_THRESHOLD`] consecutive pushes to the same shard.
 	#[inline]
 	pub(crate) fn push(&self, runnable: Runnable) {
+		// Self-spawn fast path: if the calling thread is itself
+		// a worker for THIS queue (set via `enter_worker_scope`
+		// during worker startup), push directly into that
+		// worker's local deque and skip the Injector + fence +
+		// parked check entirely.
+		//
+		// Producer and consumer are the same thread, so no
+		// cross-thread synchronisation is needed for visibility:
+		// the worker's next `pop_blocking` is sequenced-after
+		// this `push` in program order and will see the new
+		// runnable via `ctx.deque.pop()`.
+		//
+		// Side effect: any *other* workers currently parked stay
+		// parked. They'll wake on the next foreign push via the
+		// slow path below. For self-spawn cascades the work
+		// stays biased toward the spawning worker, but is still
+		// visible to peer stealers (the local deque is also a
+		// stealer target).
+		if let Some(handle) = CURRENT_WORKER.with(|w| w.get())
+			&& std::ptr::eq(handle.queue.as_ptr().cast_const(), self as *const Queue)
+		{
+			// SAFETY: `handle.deque` was installed by this same
+			// thread's `enter_worker_scope`. The scope keeps the
+			// `WorkerContext` (and the `Worker<Runnable>` it
+			// owns) alive on this thread's stack for the
+			// duration of the registration; on scope drop the
+			// thread-local is cleared *before* `WorkerContext`
+			// is dropped. So any non-`None` handle observed here
+			// points to a live `Worker<Runnable>` owned by this
+			// same thread. `Worker` is `!Sync` but used only
+			// from its owner thread, so the `&self` `push` call
+			// is sound.
+			unsafe {
+				handle.deque.as_ref().push(runnable);
+			}
+			return;
+		}
+
+		// Foreign-producer path: route via the shared Injector
+		// and wake one parked worker if any.
+		//
 		// Single-shard fast path: skip the CPU lookup, SPILL
 		// thread-local, and bitmask arithmetic — they're all
 		// dead work when `mask == 0` (which corresponds to a

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -23,10 +23,11 @@
 //!   it empties.
 //! * **Stealers.** A `Stealer<Runnable>` for each worker's deque is
 //!   stored centrally so workers can steal from each other as a
-//!   last resort before parking. Wrapped in
-//!   `Mutex<Option<Stealer>>` so the panic-respawn path can replace
-//!   a worker's slot when [`Sentry`] starts a fresh thread — the
-//!   mutex is uncontended outside that rare path.
+//!   last resort before parking. Held in `ArcSwapOption<Stealer>`
+//!   slots: the cross-worker scan path reads lock-free with a
+//!   single atomic load, and the panic-respawn path atomically
+//!   replaces a worker's slot when [`Sentry`] starts a fresh
+//!   thread.
 //!
 //! Pop order: own deque → preferred injector → other injectors,
 //! cyclic → other workers' stealers → park.
@@ -187,6 +188,12 @@ pub(crate) struct Queue {
 	/// Set on threadpool drop. Workers observing this with every
 	/// shard and stealer empty exit their loop.
 	shutdown: AtomicBool,
+	/// Test-only counter, incremented on every push that takes
+	/// the foreign-producer path (i.e. did *not* engage the
+	/// worker self-spawn fast path). Used by integration tests
+	/// to assert the fast path engaged on a given workload.
+	#[cfg(test)]
+	pub(crate) foreign_pushes: AtomicUsize,
 }
 
 /// Per-worker state owned exclusively by one worker OS thread. The
@@ -231,6 +238,8 @@ impl Queue {
 			notify: Condvar::new(),
 			parked: AtomicUsize::new(0),
 			shutdown: AtomicBool::new(false),
+			#[cfg(test)]
+			foreign_pushes: AtomicUsize::new(0),
 		}
 	}
 
@@ -325,7 +334,8 @@ impl Queue {
 
 		// Foreign-producer path: route via the shared Injector
 		// and wake one parked worker if any.
-		//
+		#[cfg(test)]
+		self.foreign_pushes.fetch_add(1, Ordering::Relaxed);
 		// Single-shard fast path: skip the CPU lookup, SPILL
 		// thread-local, and bitmask arithmetic — they're all
 		// dead work when `mask == 0` (which corresponds to a

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -401,6 +401,41 @@ async fn test_large_return_values() {
 }
 
 #[tokio::test]
+async fn test_spawn_from_worker_routes_to_local_deque() {
+	// When a closure running on a worker thread calls
+	// `pool.spawn(...)`, the new task should be picked up and
+	// executed by the same pool (potentially via the self-spawn
+	// fast path, which routes into the producing worker's own
+	// deque). We forget the inner JoinHandle to keep the task
+	// scheduled (Drop would cancel it) and use a channel for
+	// completion signalling because a worker thread is sync —
+	// it can't `.await`.
+	use std::sync::mpsc;
+
+	let pool = Arc::new(Threadpool::new(4));
+	let pool_clone = pool.clone();
+	let (tx, rx) = mpsc::channel();
+
+	pool.spawn(move || {
+		// Running on a worker thread for `pool` now. The
+		// self-spawn fast path is in effect.
+		let inner = pool_clone.spawn(move || {
+			tx.send(42u32).unwrap();
+		});
+		std::mem::forget(inner);
+	})
+	.await;
+
+	// After the outer closure returns, the worker re-enters its
+	// pop loop and finds the inner runnable in its local deque
+	// (assuming the fast path engaged) or via the cross-worker
+	// stealer scan (fallback). Either way, the inner closure
+	// must run.
+	let v = rx.recv_timeout(Duration::from_secs(5)).expect("inner closure didn't run");
+	assert_eq!(v, 42);
+}
+
+#[tokio::test]
 async fn test_nested_spawns() {
 	let pool = Arc::new(Threadpool::new(4));
 

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -436,6 +436,34 @@ async fn test_spawn_from_worker_routes_to_local_deque() {
 }
 
 #[tokio::test]
+async fn test_spawn_into_other_pool_from_worker() {
+	// A closure running on a worker of pool A calling `pool_b.spawn(...)`
+	// must route through pool B's foreign-producer path — the
+	// thread-local self-spawn handle was set for pool A, so
+	// pool B's `std::ptr::eq` queue-identity check must miss
+	// and fall back to the Injector + wake. Without that pointer-
+	// equality guard, the inner task could be misrouted into
+	// pool A's local deque and silently never run on pool B.
+	use std::sync::mpsc;
+
+	let pool_a = Arc::new(Threadpool::new(2));
+	let pool_b = Arc::new(Threadpool::new(2));
+	let pool_b_clone = pool_b.clone();
+	let (tx, rx) = mpsc::channel();
+
+	pool_a
+		.spawn(move || {
+			// Running on a worker of pool A. Spawn into pool B.
+			let inner = pool_b_clone.spawn(move || tx.send(42u32).unwrap());
+			std::mem::forget(inner);
+		})
+		.await;
+
+	let v = rx.recv_timeout(Duration::from_secs(5)).expect("cross-pool spawn didn't run");
+	assert_eq!(v, 42);
+}
+
+#[tokio::test]
 async fn test_nested_spawns() {
 	let pool = Arc::new(Threadpool::new(4));
 


### PR DESCRIPTION
## Summary

Four targeted optimisations on top of the crossbeam_deque rewrite that landed in #30. Each is independent and verified on its own commit, so they can be reviewed/landed/bisected separately if needed.

## Changes (in commit order)

### 1. `mask == 0` SPILL skip + `#[inline]` on hot paths

Single-shard pools (mask==0, which is exactly the 1-worker case given the `next_power_of_two().min(8)` shard formula) now skip the SPILL thread-local + bitmask arithmetic in `push`. The SeqCst fence + parked-check still run — producer↔worker synchronisation is independent of shard count. `Queue::push` and `Queue::pop_blocking` also get `#[inline]` so they fold into `Threadpool::spawn`'s codegen path.

Motivated by the `spawn_overhead/1w/N` regression observed in the first run of #30's benches; SPILL is dead work for 1-worker pools.

### 2. ArcSwapOption stealer slots

Stealers move from `CachePadded<Mutex<Option<Stealer>>>` to `CachePadded<ArcSwapOption<Stealer>>`. Lock-free read on the cross-worker steal-scan path; the panic-respawn write path stays atomic. Adds `arc-swap = "1.7"`. Saves ~30 ns per stealer probe on cold pops where workers walk the full stealers array.

### 3. Worker self-spawn fast path

When a closure running on a worker calls `pool.spawn(...)`, the runnable is pushed directly into that worker's own local deque, skipping the shared Injector, the SeqCst fence, and the parked check entirely. Producer and consumer are the same thread, so no cross-thread synchronisation is needed.

Mechanism: thread-local `CURRENT_WORKER` holding raw pointers `(queue, deque)`. Set by a new `Queue::enter_worker_scope(&ctx)` called once per worker thread on startup, cleared by the returned RAII `WorkerScope` on drop. The safety argument lives in the `push` doc comment: the scope keeps the `WorkerContext` alive on the worker's stack while the TLS is set, and only the owning thread ever reads its own TLS.

Adds `test_spawn_from_worker_routes_to_local_deque` integration test.

## Eventcount parking — deferred

The eventcount park primitive (item #1 from the design discussion that produced #30) is **not** in this PR. Realistic gain on `round_trip` is ~300-500 ns out of the current 5 µs gap to rayon; most of the remaining gap is `async-task` overhead + `Injector` push/steal cost, not the park primitive itself. Want to see bench numbers from this PR first before committing to that rewrite + loom proof rework. Plan: open a focused follow-up PR if `round_trip/*` benches still show the park primitive dominating.

## Verification

* `cargo test`: **36/36 pass** (35 existing + 1 new self-spawn test)
* `cargo bench --no-run`: all 7 bench binaries compile
* `RUSTFLAGS='--cfg loom' cargo test --test loom_queue`: **4/4 pass** — the loom model doesn't exercise self-spawn (its producer is a separate thread), and the foreign-producer Dekker fence proof from #30 is unchanged
* `cargo clippy --all-targets --all-features -- -D warnings`: clean

## Test plan

- [x] Integration tests pass including the new self-spawn test
- [x] Loom 4/4
- [x] Clippy clean
- [ ] `vs_*` benches on a quiet 32-core Linux box (follow-up):
  * `spawn_overhead/1w/N` — was the 1w regression on #30; expect mask==0 path to close it
  * `round_trip/*` — should hold parity (no park-primitive change here)
  * `multi_producer/*` — should hold the AP wins
  * Self-spawn workloads — N/A in current bench harness, but the new test confirms the path works