### PR TITLE
Make `spawn_local` unsafe; document + demonstrate the leak unsoundness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,29 @@ jobs:
           RUSTFLAGS: "--cfg loom"
           LOOM_MAX_PREEMPTIONS: "3"
         run: cargo test --release --test loom_queue
+
+  # `tests/unsound.rs` is an executable demonstration of the
+  # `spawn_local` leak-unsoundness (see its module docs). It exercises
+  # undefined behaviour on purpose, so its result is not guaranteed:
+  # it usually "passes" because the freed stack slot still reads back as
+  # a valid integer, but it could fault on some toolchain/platform. We
+  # therefore RUN it (so the demonstration cannot silently rot or stop
+  # compiling) but mark the whole job `continue-on-error` so a failure
+  # never blocks CI. The test is `#[ignore]`d, so the normal `test` jobs
+  # skip it; this job runs it explicitly with `--ignored`.
+  unsound:
+    name: Unsoundness demo (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run the unsoundness demonstration (non-blocking)
+        run: cargo test --test unsound -- --ignored --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- **`spawn_local` is now `unsafe`.** Both `Threadpool::spawn_local` and
+  the free `affinitypool::spawn_local` are marked `unsafe fn`. They
+  accept closures that borrow non-`'static` data, and their soundness
+  depends on the returned future's destructor running (it blocks until
+  the worker stops touching the borrows). Because safe code can skip a
+  destructor by leaking the future (`mem::forget`, `Box::leak`, an
+  `Rc`/`Arc` cycle, a leaked enclosing future), that obligation cannot
+  be guaranteed by the type system and is now the caller's
+  responsibility via an `# Safety` contract: **do not leak the returned
+  future while it borrows non-`'static` data.** This is the classic
+  leak-based unsoundness (the pre-1.0 `std::thread::scoped` hole); there
+  is no sound, fully safe `spawn_local` in async Rust — the only
+  leak-proof design is a synchronous scoped API, which has no
+  `.await`-able equivalent. Migration: wrap existing calls in `unsafe`;
+  the common `pool.spawn_local(..).await` (or dropping the future
+  normally) already upholds the contract. Closures that capture only
+  `'static` data should move to the safe `spawn`. See `tests/unsound.rs`
+  for a demonstration of the hazard.
+
 ### Behavioural notes
 
 - **Worker self-spawn fast path.** When a closure running on a

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ async fn process_data() {
 
 ### Local Spawning
 
-Use `spawn_local` when you need to borrow data without the 'static lifetime requirement:
+Use `spawn_local` when you need to borrow data without the `'static` lifetime requirement.
+
+`spawn_local` is **`unsafe`**: the closure may borrow non-`'static` data, and that borrow stays sound only as long as the returned future is *not leaked* (`mem::forget`, `Box::leak`, an `Rc`/`Arc` cycle, …) before the borrow ends. Awaiting it — or simply letting it drop — upholds the contract; leaking it while it borrows local data is a use-after-free. This cannot be enforced statically in async Rust, which is why the API is `unsafe` rather than safe; if your closure only captures `'static` data, prefer the safe `spawn`.
 
 ```rust
 use affinitypool::Threadpool;
@@ -138,12 +140,16 @@ async fn main() {
     let data = vec![1, 2, 3, 4, 5];
     let multiplier = 10;
     
-    // spawn_local allows borrowing local data
-    let result = pool.spawn_local(|| {
-        data.iter()
-            .map(|x| x * multiplier)
-            .collect::<Vec<_>>()
-    }).await;
+    // spawn_local allows borrowing local data.
+    // SAFETY: the future is awaited immediately and never leaked, so the
+    // borrows of `data`/`multiplier` cannot outlive it.
+    let result = unsafe {
+        pool.spawn_local(|| {
+            data.iter()
+                .map(|x| x * multiplier)
+                .collect::<Vec<_>>()
+        })
+    }.await;
     
     println!("Result: {result:?}");  // [10, 20, 30, 40, 50]
     

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -232,7 +232,8 @@ fn bench_spawn_local_overhead(c: &mut Criterion) {
 				rt.block_on(async move {
 					let pool = Threadpool::new(4);
 					// Warm up.
-					pool.spawn_local(|| ()).await;
+					// SAFETY: awaited immediately; the future is never leaked.
+					unsafe { pool.spawn_local(|| ()) }.await;
 					let mut total = Duration::ZERO;
 					for _ in 0..iters {
 						let start = Instant::now();
@@ -241,7 +242,8 @@ fn bench_spawn_local_overhead(c: &mut Criterion) {
 						// collecting handles (the borrow would prevent
 						// stacking them in a Vec without boxing).
 						for _ in 0..count {
-							pool.spawn_local(|| black_box(())).await;
+							// SAFETY: awaited immediately; the future is never leaked.
+							unsafe { pool.spawn_local(|| black_box(())) }.await;
 						}
 						total += start.elapsed();
 					}

--- a/examples/alloc_count.rs
+++ b/examples/alloc_count.rs
@@ -78,7 +78,8 @@ fn main() {
 		// lazy allocations should not be charged to the per-spawn delta.
 		for _ in 0..16 {
 			pool.spawn(|| ()).await;
-			pool.spawn_local(|| ()).await;
+			// SAFETY: awaited immediately; the future is never leaked.
+			unsafe { pool.spawn_local(|| ()) }.await;
 		}
 
 		report_spawn(&pool, "spawn(empty closure)", 1_000).await;
@@ -106,7 +107,8 @@ async fn report_spawn(pool: &Threadpool, label: &str, n: usize) {
 async fn report_spawn_local(pool: &Threadpool, label: &str, n: usize) {
 	let before = Snapshot::take();
 	for _ in 0..n {
-		let v = pool.spawn_local(|| black_box(0u32)).await;
+		// SAFETY: awaited immediately; the future is never leaked.
+		let v = unsafe { pool.spawn_local(|| black_box(0u32)) }.await;
 		black_box(v);
 	}
 	let after = Snapshot::take();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@ where
 	F: Send + 'pool,
 	R: Send + 'pool,
 {
-	dbg!("called 7");
 	if let Some(threadpool) = THREADPOOL.get() {
 		threadpool.spawn_local(func).await
 	} else {
@@ -188,7 +187,6 @@ impl Threadpool {
 		F: Send + 'pool,
 		R: Send + 'pool,
 	{
-		dbg!("called 6");
 		let queue = self.data.queue.clone();
 		let schedule = move |runnable: Runnable| queue.push(runnable);
 		// Same `catch_unwind` wrapper rationale as `spawn` — keep

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ where
 	F: Send + 'pool,
 	R: Send + 'pool,
 {
+	dbg!("called 7");
 	if let Some(threadpool) = THREADPOOL.get() {
 		threadpool.spawn_local(func).await
 	} else {
@@ -187,6 +188,7 @@ impl Threadpool {
 		F: Send + 'pool,
 		R: Send + 'pool,
 	{
+		dbg!("called 6");
 		let queue = self.data.queue.clone();
 		let schedule = move |runnable: Runnable| queue.push(runnable);
 		// Same `catch_unwind` wrapper rationale as `spawn` — keep

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,14 +49,34 @@ where
 /// If no global threadpool has been created, then this function
 /// runs the provided closure immediately, without passing it to
 /// a blocking threadpool.
-pub async fn spawn_local<'pool, F, R>(func: F) -> R
+///
+/// # Safety
+///
+/// `func` may borrow non-`'static` data. Soundness relies on the future
+/// returned by this `async fn` being dropped (or driven to completion)
+/// before those borrows expire — its destructor blocks until the worker
+/// has stopped touching them. The caller must therefore **not leak that
+/// future** (via [`mem::forget`](std::mem::forget), `Box::leak`, an
+/// `Rc`/`Arc` cycle, or by embedding it in another future that is then
+/// leaked) while it still borrows non-`'static` data. Leaking it lets a
+/// worker read data after it has gone out of scope — a data race and a
+/// use-after-free.
+///
+/// This hazard cannot be designed away in async Rust; see
+/// [`Threadpool::spawn_local`] for the full rationale. If `func`
+/// captures only `'static` data, use the safe [`spawn`] instead.
+pub async unsafe fn spawn_local<'pool, F, R>(func: F) -> R
 where
 	F: FnOnce() -> R,
 	F: Send + 'pool,
 	R: Send + 'pool,
 {
 	if let Some(threadpool) = THREADPOOL.get() {
-		threadpool.spawn_local(func).await
+		// SAFETY: the no-leak obligation is forwarded to our own caller
+		// via this fn's `# Safety` contract — the future they must not
+		// leak is the one this `async fn` returns, which owns the inner
+		// `SpawnFuture` across the `.await`.
+		unsafe { threadpool.spawn_local(func) }.await
 	} else {
 		func()
 	}
@@ -158,8 +178,10 @@ impl Threadpool {
 	/// runnable to a worker, so the drop returns immediately. Once
 	/// polled, dropping the future cancels the task; if the worker is
 	/// currently running the closure, the dropping thread is parked
-	/// until the worker has finished, so closure borrows of `'pool`
-	/// data cannot dangle.
+	/// until the worker has finished, so that — *provided the future is
+	/// not leaked* — closure borrows of `'pool` data cannot dangle. See
+	/// [Safety](#safety) for the obligation that "provided" places on
+	/// the caller.
 	///
 	/// # Drop-blocking caveats
 	///
@@ -181,7 +203,30 @@ impl Threadpool {
 	///    `let _ = pool.spawn_local(|| …);` from inside its own
 	///    worker. Polling once and *then* dropping still queues and
 	///    cancels normally.
-	pub fn spawn_local<'pool, F, R>(&'pool self, func: F) -> SpawnFuture<'pool, R>
+	///
+	/// # Safety
+	///
+	/// The returned [`SpawnFuture`] may borrow non-`'static` data through
+	/// `func`. Its `Drop` impl is the *only* thing that guarantees the
+	/// worker has stopped touching those borrows before they expire — it
+	/// blocks on cancellation. The caller must therefore ensure that
+	/// destructor actually runs before the borrowed data goes out of
+	/// scope: the future must be dropped (or driven to completion) and
+	/// **must not be leaked** — not via [`mem::forget`](std::mem::forget),
+	/// `Box::leak`, `ManuallyDrop`, an `Rc`/`Arc` cycle, nor by being
+	/// embedded in another future that is itself leaked.
+	///
+	/// Leaking the future while it still borrows non-`'static` data lets
+	/// a worker read those borrows after they are gone — a data race and
+	/// a use-after-free. This obligation cannot be enforced statically in
+	/// async Rust (a future is a value that safe code may always leak),
+	/// which is why the function is `unsafe` rather than relying on the
+	/// destructor alone; `tests/unsound.rs` demonstrates the break. The
+	/// only fully safe alternative is a *synchronous* scoped API
+	/// (`std::thread::scope` / `rayon::scope`), which has no `.await`-able
+	/// equivalent. If every captured borrow is `'static`, prefer
+	/// [`spawn`](Self::spawn), which is safe.
+	pub unsafe fn spawn_local<'pool, F, R>(&'pool self, func: F) -> SpawnFuture<'pool, R>
 	where
 		F: FnOnce() -> R,
 		F: Send + 'pool,
@@ -192,14 +237,19 @@ impl Threadpool {
 		// Same `catch_unwind` wrapper rationale as `spawn` — keep
 		// panics off the worker thread, surface them on the awaiter.
 		// SAFETY: `async_task::Builder::spawn_unchecked` lifts the
-		// `'static` bound on the future. Soundness is preserved by:
+		// `'static` bound on the future. The erased lifetime is sound
+		// given:
 		//   1. `SpawnFuture<'pool, R>` carries the `'pool` borrow, so
 		//      the future cannot outlive the pool.
 		//   2. `SpawnFuture::drop` blocks (via `Task::cancel().await`)
-		//      until the runnable has stopped, so the closure's
-		//      `'pool` borrows are not accessed after they expire.
-		//   3. The same `mem::forget` caveat as the previous
-		//      implementation applies — see `local.rs` module docs.
+		//      until the runnable has stopped, so the closure's `'pool`
+		//      borrows are not accessed after they expire — *as long as
+		//      that destructor runs*.
+		//   3. A destructor is not guaranteed to run, so (2) cannot be
+		//      discharged here. That remaining obligation — do not leak
+		//      the future while it borrows non-`'static` data — is the
+		//      caller's, via this fn's `unsafe` contract (see `# Safety`
+		//      and the `local.rs` module docs).
 		let (runnable, task) = unsafe {
 			TaskBuilder::new().spawn_unchecked(
 				move |()| async move { std::panic::catch_unwind(std::panic::AssertUnwindSafe(func)) },

--- a/src/local.rs
+++ b/src/local.rs
@@ -97,7 +97,6 @@ impl<R> Future for SpawnFuture<'_, R> {
 	type Output = R;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-		dbg!("called 3");
 		// Structural pinning: we never move out of `self.state` except
 		// to replace it whole, and the Task inside is moved only when
 		// it has just been constructed by `mem::replace` (i.e. is no
@@ -108,7 +107,6 @@ impl<R> Future for SpawnFuture<'_, R> {
 		// caller awaiting the future doesn't need a second poll just
 		// to register the waker.
 		if matches!(this.state, State::Pending { .. }) {
-			dbg!("called 4");
 			match mem::replace(&mut this.state, State::Done) {
 				State::Pending {
 					runnable,

--- a/src/local.rs
+++ b/src/local.rs
@@ -97,6 +97,7 @@ impl<R> Future for SpawnFuture<'_, R> {
 	type Output = R;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		dbg!("called 3");
 		// Structural pinning: we never move out of `self.state` except
 		// to replace it whole, and the Task inside is moved only when
 		// it has just been constructed by `mem::replace` (i.e. is no
@@ -107,6 +108,7 @@ impl<R> Future for SpawnFuture<'_, R> {
 		// caller awaiting the future doesn't need a second poll just
 		// to register the waker.
 		if matches!(this.state, State::Pending { .. }) {
+			dbg!("called 4");
 			match mem::replace(&mut this.state, State::Done) {
 				State::Pending {
 					runnable,

--- a/src/local.rs
+++ b/src/local.rs
@@ -14,15 +14,30 @@
 //! semantic of `Task::cancel().await`; we run it on a parker-based
 //! `block_on` because `Drop` is synchronous.
 //!
-//! # Leak amplification
+//! # Leak amplification and the `unsafe` contract
 //!
-//! `mem::forget`-ing a `SpawnFuture` keeps the underlying `Task` alive
-//! (its memory is leaked), but the runnable may still be in the pool
-//! queue. The current implementation does not statically prevent the
-//! borrow checker from accepting code that runs the closure after the
-//! borrowed data has gone out of scope. This is the same soundness
-//! profile as the previous implementation; closing it would require an
-//! API change (a scoped spawn like `std::thread::scope`).
+//! The drop-blocking contract above is only load-bearing if the
+//! destructor actually runs, and Rust never guarantees that. Safe code
+//! can `mem::forget` a `SpawnFuture` (or leak it via `Box::leak`, a
+//! `ManuallyDrop`, an `Rc`/`Arc` cycle, or a leaked enclosing future):
+//! its `Task` stays alive but the runnable may still be queued or
+//! running, and the closure can then read borrowed producer-stack data
+//! after it has gone out of scope. That is a use-after-free reachable
+//! from entirely safe code.
+//!
+//! This cannot be closed by an implementation change. A future is a
+//! value, leaking a value is always safe, so a destructor can never be
+//! a sound safety barrier in async code. The only leak-proof design is
+//! a *synchronous* scoped API (`std::thread::scope` / `rayon::scope`),
+//! where the join happens as the scope call returns — a barrier safe
+//! code cannot skip. There is no `.await`-able equivalent.
+//!
+//! Because the hazard is intrinsic, [`Threadpool::spawn_local`] and the
+//! free [`crate::spawn_local`] are `unsafe`: their `# Safety` contract
+//! requires the caller never to leak the returned future while it
+//! borrows non-`'static` data. Normal use (`.await`, or a plain drop)
+//! upholds it automatically; `tests/unsound.rs` is the one documented
+//! way it breaks.
 
 use async_task::{Runnable, Task};
 use std::any::Any;
@@ -71,6 +86,10 @@ enum State<R> {
 /// cancels the task; if the worker is currently running the closure,
 /// the dropping thread is parked until the worker has finished. See
 /// module docs.
+///
+/// Must **not** be leaked (e.g. via `mem::forget`) while it borrows
+/// non-`'static` data — that is the safety obligation of
+/// [`Threadpool::spawn_local`], the `unsafe` fn that produces it.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SpawnFuture<'pool, R> {
 	state: State<R>,

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -112,7 +112,9 @@ async fn test_spawn_local() {
 
 	// Test that spawn_local works with local borrowing
 	let data = [1, 2, 3, 4, 5];
-	let result = pool.spawn_local(|| data.iter().sum::<i32>()).await;
+	// SAFETY: the future is awaited immediately and never leaked, so the
+	// borrow of `data` cannot outlive it.
+	let result = unsafe { pool.spawn_local(|| data.iter().sum::<i32>()) }.await;
 
 	assert_eq!(result, 15);
 	// Verify we can still use data after spawn_local
@@ -680,13 +682,15 @@ async fn test_spawn_local_lifetime_safety() {
 	{
 		let local_data = [1, 2, 3, 4, 5];
 
-		let result = pool
-			.spawn_local(move || {
+		// SAFETY: awaited immediately; the future is never leaked.
+		let result = unsafe {
+			pool.spawn_local(move || {
 				// Access the local data - this is safe because spawn_local
 				// ensures the task completes before the future is dropped
 				local_data.iter().sum::<i32>()
 			})
-			.await;
+		}
+		.await;
 
 		assert_eq!(result, 15);
 	}
@@ -695,11 +699,14 @@ async fn test_spawn_local_lifetime_safety() {
 	let mut results = Vec::new();
 	for i in 0..5 {
 		let data = [i; 5];
+		// SAFETY: awaited immediately; the future is never leaked.
 		results.push(
-			pool.spawn_local(move || {
-				// Each closure captures different data
-				data.iter().sum::<i32>()
-			})
+			unsafe {
+				pool.spawn_local(move || {
+					// Each closure captures different data
+					data.iter().sum::<i32>()
+				})
+			}
 			.await,
 		);
 	}
@@ -711,16 +718,19 @@ async fn test_spawn_local_lifetime_safety() {
 		let vec_data = vec![1, 2, 3];
 		let tuple_data = (42, "test");
 
-		let result = pool
-			.spawn_local(move || format!("{} - {:?} - {:?}", string_data, vec_data, tuple_data))
-			.await;
+		// SAFETY: awaited immediately; the future is never leaked.
+		let result = unsafe {
+			pool.spawn_local(move || format!("{} - {:?} - {:?}", string_data, vec_data, tuple_data))
+		}
+		.await;
 
 		assert_eq!(result, "Hello, World! - [1, 2, 3] - (42, \"test\")");
 	}
 
 	// Test 4: Verify spawn_local can safely reference pool lifetime
 	let value = 100;
-	let result = pool.spawn_local(|| value * 2).await;
+	// SAFETY: awaited immediately; the future is never leaked.
+	let result = unsafe { pool.spawn_local(|| value * 2) }.await;
 	assert_eq!(result, 200);
 }
 
@@ -741,7 +751,9 @@ async fn test_spawn_local_no_nested_deadlock() {
 			// Create a SpawnFuture and immediately drop it
 			// This should NOT deadlock thanks to our detection
 			{
-				let _future = pool.spawn_local(|| 42);
+				// SAFETY: dropped at the end of this block, never leaked;
+				// the closure captures nothing borrowed in any case.
+				let _future = unsafe { pool.spawn_local(|| 42) };
 				// Future dropped here without awaiting
 			}
 
@@ -777,7 +789,8 @@ async fn test_spawn_local_single_worker_drop_without_poll() {
 					// With lazy scheduling the runnable is never
 					// queued, so Drop returns immediately.
 					let inner = pool.clone();
-					let _future = inner.spawn_local(|| 42);
+					// SAFETY: dropped without polling and never leaked.
+					let _future = unsafe { inner.spawn_local(|| 42) };
 					"ok"
 				})
 				.await
@@ -960,9 +973,15 @@ async fn test_forget_spawn_local_future_does_not_dangle() {
 	let pool = Threadpool::new(2);
 	let drops = Arc::new(AtomicUsize::new(0));
 	let tracker = DropTracker(drops.clone());
-	let mut fut = Box::pin(pool.spawn_local(move || {
-		let _t = tracker;
-	}));
+	// SAFETY: the closure captures `tracker` by move (owned, no borrow of
+	// non-`'static` data). Although this future is deliberately
+	// `mem::forget`-ed below, there are no borrows that could dangle —
+	// this exercises the leak-safety of the memory path, not a borrow.
+	let mut fut = Box::pin(unsafe {
+		pool.spawn_local(move || {
+			let _t = tracker;
+		})
+	});
 	// Poll once with a noop waker so the future transitions Init -> Running
 	// and pushes the task to the injector. After this point the worker owns
 	// an Arc to the shared data and will free the captured tracker when it
@@ -1018,6 +1037,7 @@ fn _spawn_send_bound_compile_check() {
 fn _spawn_local_send_bound_compile_check() {
 	fn assert_send<T: Send>(_: T) {}
 	let pool = Threadpool::new(1);
-	let fut = pool.spawn_local(|| 42u64);
+	// SAFETY: never leaked; the closure captures nothing. Compile-time check.
+	let fut = unsafe { pool.spawn_local(|| 42u64) };
 	assert_send(fut);
 }

--- a/tests/unsound.rs
+++ b/tests/unsound.rs
@@ -1,0 +1,73 @@
+use std::{
+	pin::Pin,
+	sync::mpsc,
+	task::{self, Context, Poll},
+};
+
+struct PollAndLeak<T>(Option<Pin<Box<T>>>);
+
+impl<T: Future<Output = ()>> Future for PollAndLeak<T> {
+	type Output = ();
+
+	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		dbg!("CALLED");
+		let mut future = self.get_mut().0.take().unwrap();
+		dbg!("CALLED 2");
+		let res = dbg!(future.as_mut().poll(cx));
+		dbg!("CALLED 3");
+		match res {
+			Poll::Ready(_) => Poll::Ready(()),
+			Poll::Pending => {
+				std::mem::forget(future);
+				Poll::Ready(())
+			}
+		}
+	}
+}
+
+#[test]
+fn trigger_unsoundness() {
+	affinitypool::Builder::new().build().build_global().unwrap();
+	let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+
+	rt.block_on(async {
+		let (send, recv) = mpsc::channel();
+		let (sendback, recvback) = mpsc::channel();
+
+		{
+			let mut v = 1;
+			{
+				let v_ref = &v;
+				println!("MAIN THREAD SPAWNING");
+				let future = affinitypool::spawn_local(move || {
+					println!("THREAD STARTING");
+					//  Wait for the spawning thread to drop the v reference
+					recv.recv().unwrap();
+					println!("THREAD ACCESSING");
+					// Access the reference.
+					println!("{}", v_ref);
+					println!("THREAD FINISHED");
+					// Notify that we actually did so.
+					sendback.send(()).unwrap();
+				});
+
+				println!("MAIN THREAD POLLING ONCE");
+				let future = PollAndLeak(Some(Box::pin(future)));
+				future.await;
+			}
+			v = 2;
+			std::hint::black_box(v);
+		}
+
+		// The thread has not finished yet
+		println!("MAIN THREAD DROPPED REFERENCE");
+		assert!(recvback.try_recv().is_err());
+		println!("TELL THREAD TO CONTINUE");
+		send.send(()).unwrap();
+		// But it will after we send the communication over the channel.
+		// At this point the thread will have accessed the reference to the already dropped v.
+		println!("CHECK IF THREAD ACTUALLY RAN");
+		assert!(recvback.recv().is_ok());
+		println!("TEST FINISHED");
+	})
+}

--- a/tests/unsound.rs
+++ b/tests/unsound.rs
@@ -10,11 +10,8 @@ impl<T: Future<Output = ()>> Future for PollAndLeak<T> {
 	type Output = ();
 
 	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-		dbg!("CALLED");
 		let mut future = self.get_mut().0.take().unwrap();
-		dbg!("CALLED 2");
-		let res = dbg!(future.as_mut().poll(cx));
-		dbg!("CALLED 3");
+		let res = future.as_mut().poll(cx);
 		match res {
 			Poll::Ready(_) => Poll::Ready(()),
 			Poll::Pending => {

--- a/tests/unsound.rs
+++ b/tests/unsound.rs
@@ -1,9 +1,70 @@
+//! Executable demonstration of the `spawn_local` soundness hazard.
+//!
+//! # The bug
+//!
+//! `affinitypool::spawn_local` (and `Threadpool::spawn_local`) accept a
+//! closure that may **borrow** non-`'static` data from the caller's
+//! stack. To make that lifetime erasure work, the returned future runs a
+//! blocking cancellation in its `Drop` impl: dropping the future parks
+//! the current thread until the worker has stopped running the closure,
+//! so the closure's borrows are guaranteed dead before they expire.
+//!
+//! That guarantee relies entirely on the destructor running, and Rust
+//! does **not** guarantee destructors run. Safe code can skip one with
+//! `std::mem::forget`, `Box::leak`, a `ManuallyDrop`, an `Rc`/`Arc`
+//! cycle, or by nesting the future inside another future that is itself
+//! leaked. If the future is leaked while it still borrows caller data,
+//! the worker goes on to read that data after it has gone out of scope:
+//! a data race and a use-after-free. This is the classic
+//! "leak ⇒ unsoundness" hole — the same one that sank the pre-1.0
+//! `std::thread::scoped` API.
+//!
+//! This test reproduces exactly that. `PollAndLeak` polls the spawn
+//! future once (so the closure is scheduled and the worker parks on a
+//! channel) and then `mem::forget`s it instead of dropping it. The
+//! borrow region for `v` then ends, `v` is mutated, and only afterwards
+//! is the worker told to read `&v`.
+//!
+//! # Why there is no fix in async Rust
+//!
+//! There is no sound, fully safe `spawn_local` in today's async Rust. A
+//! future is a *value*, and safe code may always leak a value, so a
+//! future's destructor can never be a load-bearing safety barrier. The
+//! only construct whose completion safe code cannot skip is a returning
+//! stack frame — which is why the one sound design is a *synchronous*
+//! scoped API (`std::thread::scope` / `rayon::scope`), where the join
+//! happens as the scope call returns. That shape cannot be expressed
+//! over `.await`: awaiting hands control to an executor that is never
+//! obliged to poll the future again.
+//!
+//! # How to use `spawn_local` safely
+//!
+//! Because the hazard cannot be designed out, `spawn_local` is `unsafe`.
+//! The way to ensure safety is to use it correctly: **never leak the
+//! returned future while it borrows non-`'static` data** — always let it
+//! drop, or drive it to completion, before the borrows end. The ordinary
+//! patterns (`pool.spawn_local(..).await`, or just dropping the future)
+//! all uphold this; only a deliberate leak like the one below breaks it.
+//! If the closure captures only `'static` data, use the safe
+//! `affinitypool::spawn` instead.
+//!
+//! This test is run in CI but is **not** allowed to block it: it
+//! exercises undefined behaviour, whose observable result is not
+//! guaranteed (it usually "passes" because the freed stack slot still
+//! reads back as a valid integer). It exists as an executable record of
+//! the hazard, not as a correctness check — see the non-blocking
+//! `unsound` job in `.github/workflows/ci.yml`.
+
 use std::{
 	pin::Pin,
 	sync::mpsc,
-	task::{self, Context, Poll},
+	task::{Context, Poll},
 };
 
+/// A future adapter that polls its inner future exactly once and then,
+/// if it is still `Pending`, **leaks** it via [`std::mem::forget`]
+/// instead of dropping it — deliberately skipping the `SpawnFuture`
+/// destructor that `spawn_local`'s soundness depends on.
 struct PollAndLeak<T>(Option<Pin<Box<T>>>);
 
 impl<T: Future<Output = ()>> Future for PollAndLeak<T> {
@@ -22,7 +83,13 @@ impl<T: Future<Output = ()>> Future for PollAndLeak<T> {
 	}
 }
 
+/// Drives `spawn_local` into a use-after-free by leaking its future
+/// mid-flight. See the module docs for the full explanation.
+///
+/// `#[ignore]`d so the default `cargo test` run never executes it; CI
+/// runs it explicitly in a dedicated, non-blocking job.
 #[test]
+#[ignore = "demonstrates undefined behaviour; run explicitly, non-blocking (see the `unsound` CI job)"]
 fn trigger_unsoundness() {
 	affinitypool::Builder::new().build().build_global().unwrap();
 	let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
@@ -36,17 +103,25 @@ fn trigger_unsoundness() {
 			{
 				let v_ref = &v;
 				println!("MAIN THREAD SPAWNING");
-				let future = affinitypool::spawn_local(move || {
-					println!("THREAD STARTING");
-					//  Wait for the spawning thread to drop the v reference
-					recv.recv().unwrap();
-					println!("THREAD ACCESSING");
-					// Access the reference.
-					println!("{}", v_ref);
-					println!("THREAD FINISHED");
-					// Notify that we actually did so.
-					sendback.send(()).unwrap();
-				});
+				// SAFETY: this call is intentionally UNSOUND — it exists to
+				// demonstrate the hazard. `spawn_local`'s contract (do not
+				// leak the returned future while it borrows `v`) is
+				// deliberately violated below by `PollAndLeak`, which polls
+				// once and then `mem::forget`s the future. Do NOT copy this
+				// pattern; correct callers `.await` or drop the future.
+				let future = unsafe {
+					affinitypool::spawn_local(move || {
+						println!("THREAD STARTING");
+						//  Wait for the spawning thread to drop the v reference
+						recv.recv().unwrap();
+						println!("THREAD ACCESSING");
+						// Access the reference.
+						println!("{}", v_ref);
+						println!("THREAD FINISHED");
+						// Notify that we actually did so.
+						sendback.send(()).unwrap();
+					})
+				};
 
 				println!("MAIN THREAD POLLING ONCE");
 				let future = PollAndLeak(Some(Box::pin(future)));


### PR DESCRIPTION
## Summary

`spawn_local` is unsound as a *safe* API. This PR keeps the demonstration test, explains why the hole is intrinsic to async Rust, and resolves it by moving the safety contract onto the caller via `unsafe` rather than pretending a destructor can uphold it.

## The bug

`Threadpool::spawn_local` (and the free `affinitypool::spawn_local`) accept a closure that **borrows non-`'static` data**. The lifetime erasure (`async_task::spawn_unchecked`) is made "sound" only by the returned `SpawnFuture`'s `Drop`, which blocks the dropping thread until the worker has stopped touching those borrows.

The bug was introduced based on a subtle misunderstanding of the `std::pin::Pin` guarantees. When `Pin`-ing a pointer you must uphold the invariant that the destructor will be run before the pinned value is moved. This might seem like it would guarantee that destructors are run as values are generally either moved or dropped. However if the value is never moved, like with `std::mem::forget` it is fine to not run the destructor.

`tests/unsound.rs` demonstrates it: `PollAndLeak` polls the spawn future once (scheduling the closure, which parks on a channel) and then `mem::forget`s it; the borrow region for `v` ends, `v` is mutated, and only then is the worker told to read the now-dangling `&v`.

> **Note on CI:** a green `cargo test` run does *not* mean "no UB" — UB is allowed to look like it works (the freed stack slot still reads back as a valid integer). And the existing green **Miri** check does not cover this test: the Miri job is scoped to `--lib` and `--test async_task_smoke`, so it never runs `tests/unsound.rs`.

## Why there is no fix in async Rust

After the leakopocolypse it become clear that rust cannot trust destructors to run for safety. The then available thread::guard, which could be used to access local references in another thread, had to be changed to thread::scope, where instead of a guard that has to be dropped returning out of the scope guarantees that some work can be done to ensure references remain valid. A similar solution is not possible with async code as the whole point of a future is to be able to yield at any time at which point the future can be leaked.

## Resolution

Since the hazard cannot be designed out, make it explicit and visible at every call site:

- **`spawn_local` is now `unsafe`** — both `Threadpool::spawn_local` and the free `spawn_local` — with `# Safety` docs spelling out the contract: *do not leak the returned future while it borrows non-`'static` data.* Normal use (`.await`, or simply dropping the future) upholds it automatically; closures that capture only `'static` data should use the safe `spawn`.
- **The demo test is documented, kept in CI, but never blocks it.** It carries a module doc comment describing the bug and why it is unfixable, is `#[ignore]`d so the normal `test` jobs skip it, and is run explicitly by a new `unsound` job marked `continue-on-error: true`. Rationale: it exercises UB on purpose, so its observable result is not guaranteed — it must keep being compiled and run, but a failure must not break CI.
- **Clippy fixed** — the unused `self` import in the test.
- Internal call sites (tests, example, bench, the free-fn forwarder) wrapped in `unsafe` with SAFETY justifications; README + CHANGELOG updated to describe the breaking change.

## Migration

Making a public fn `unsafe` is a breaking change:

```rust
// before
let r = pool.spawn_local(|| borrow_local()).await;
// after — SAFETY: awaited immediately, never leaked
let r = unsafe { pool.spawn_local(|| borrow_local()) }.await;
```


## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --all-features` — passes; `unsound` correctly skipped (ignored)
- `cargo test --test unsound -- --ignored` — runs (matches the new CI job)
