### PR TITLE
docs(claude): comment discipline — describe current state, not dev history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Guidance for AI assistants working in this repository.
+
+## Comment discipline
+
+Code comments must describe the code as it currently stands, not the development history that produced it. Do not narrate changes ("this now does X", "previously returned Y", "no longer gated") or reference bugs or behaviours that have since been fixed — once a fix has landed, drop the mention and describe the correct behaviour. Genuinely open limitations may be noted, but neutrally: no dates, no "found while…", no PR/issue references, no root-cause internals. The rationale for a change belongs in the commit message or PR description, not inline.


### PR DESCRIPTION
Adds `CLAUDE.md` (the repo had none) with a **Comment discipline** section:

> Code comments must describe the code as it currently stands, not the development history that produced it. No narrating changes or referencing since-fixed bugs; open limitations noted neutrally; rationale goes in the commit/PR, not inline.