### PR TITLE
Gate CPU pinning behind a `pinning` feature; route by thread-ID hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
-      - name: Run tests
+      - name: Run tests (default features)
+        run: cargo test --verbose
+
+      - name: Run tests (all features)
         run: cargo test --all-features --verbose
 
   format:
@@ -66,7 +69,10 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Run clippy
+      - name: Run clippy (default features)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run clippy (all features)
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   bench:
@@ -83,7 +89,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check benchmarks compile
-        run: cargo bench --no-run
+        run: cargo bench --no-run --all-features
 
   # The 0.6.0 rewrite shrank the unsafe surface (task allocation and
   # waker synchronisation moved into `async-task`, which carries its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## Unreleased
 
+### Added
+
+- **`pinning` cargo feature (opt-in CPU-core affinity).** All CPU
+  pinning code — the `affinity` module and the `libc`/`winapi`
+  platform FFI — now lives behind the `pinning` feature, which is off
+  by default. The default build carries no pinning `unsafe` code.
+
+### Changed
+
+- **`Builder::thread_per_core(bool)` → `Builder::with_affinity_pinning(bool)`**,
+  gated behind the `pinning` feature. (Breaking; pre-1.0.)
+- **Shard routing no longer queries the CPU.** Producers now pick a
+  shard from a cached hash of the thread ID instead of
+  `sched_getcpu()` / `GetCurrentProcessorNumber()`. This drops a
+  per-push syscall/vDSO call and removes `libc`/`winapi` from the
+  default (non-`pinning`) build, with no change to routing behaviour
+  (each producer still sticks to one shard). Also fixes routing under
+  miri, which does not support `sched_getcpu`.
+
+### Fixed
+
+- **Linux `affinity::set_for_current`** no longer calls `CPU_SET` with
+  an out-of-range core id (`>= CPU_SETSIZE`), which was undefined
+  behaviour; such ids are now rejected.
+- **macOS affinity** passed a `pthread_t` straight to
+  `thread_policy_set` (which wants a mach thread port), silently
+  failing on Intel, and matched a mislabeled `KERN_NOT_SUPPORTED`
+  constant (`0x10000003`, actually `MACH_SEND_INVALID_DEST` — the
+  symptom of that bogus port). Now routes through
+  `pthread_mach_thread_np` and matches the correct `KERN_NOT_SUPPORTED`
+  (46).
+
 ### Behavioural notes
 
 - **Worker self-spawn fast path.** When a closure running on a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ resolver = "2"
 
 [features]
 default = []
+# Opt-in CPU-core affinity pinning. Pulls in the platform `libc`/`winapi`
+# FFI and compiles the `affinity` module + `Builder::with_affinity_pinning`.
+# Off by default, so the default build carries no pinning `unsafe` code.
+pinning = ["dep:libc", "dep:winapi"]
 
 [dependencies]
 arc-swap = "1.7"
@@ -24,11 +28,13 @@ num_cpus = "1.17.0"
 parking_lot = "0.12.5"
 thiserror = "2.0.18"
 
+# `libc`/`winapi` are used only by the `affinity` pinning module, so they
+# are optional and pulled in by the `pinning` feature (see `[features]`).
 [target.'cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies]
-libc = "^0.2.186"
+libc = { version = "^0.2.186", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"] }
+winapi = { version = "^0.3.9", features = ["processthreadsapi", "winbase"], optional = true }
 
 [target.'cfg(not(loom))'.dev-dependencies]
 blocking = "1.6.2"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,18 @@ async fn main() {
 
 ### CPU Affinity
 
-Pin each worker thread to a specific CPU core for optimal performance:
+Pin each worker thread to a specific CPU core. This requires the
+opt-in `pinning` feature (off by default, so the standard build pulls
+in no platform affinity FFI):
+
+```toml
+[dependencies]
+affinitypool = { version = "0.7", features = ["pinning"] }
+```
+
+Pinning helps on bare-metal NUMA / latency-sensitive deployments; it is
+rarely beneficial (and sometimes harmful) under containers or VMs where
+"cores" are virtualised.
 
 ```rust
 use affinitypool::Builder;
@@ -75,7 +86,7 @@ use affinitypool::Builder;
 async fn main() {
     // Create a pool with one thread per CPU core, each pinned to its respective core
     let pool = Builder::new()
-        .thread_per_core(true)
+        .with_affinity_pinning(true)
         .build();
     
     // Tasks will be distributed across CPU cores

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -28,13 +28,29 @@
 //!   parked workers. (Name preserved for criterion history continuity —
 //!   the current implementation is shard-scanning, not work-stealing.)
 
-use affinitypool::{Builder, Threadpool};
+use affinitypool::Threadpool;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
+
+/// Build a one-worker-per-core pool. Pinned when the `pinning` feature is
+/// enabled; otherwise an equivalent worker-per-core pool without pinning,
+/// so this bench compiles and runs either way (use `--features pinning`
+/// to measure the actual pinned config).
+fn per_core_pool() -> Threadpool {
+	#[cfg(feature = "pinning")]
+	{
+		affinitypool::Builder::new().with_affinity_pinning(true).build()
+	}
+	#[cfg(not(feature = "pinning"))]
+	{
+		let cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+		Threadpool::new(cores)
+	}
+}
 
 /// Submit `count` empty closures and await each. The closure does no work,
 /// so the timing is dominated by spawn/poll overhead.
@@ -303,9 +319,10 @@ fn bench_steal_imbalance(c: &mut Criterion) {
 	group.finish();
 }
 
-/// `thread_per_core` configuration, steady-state busy. Matches the
+/// One-worker-per-core configuration, steady-state busy. Matches the
 /// production deployment in `surrealdb` and gives us a fixed reference
-/// point that sweeps across the changes.
+/// point that sweeps across the changes. Pinned when built with
+/// `--features pinning` (see `per_core_pool`).
 fn bench_per_core_steady_state(c: &mut Criterion) {
 	let rt = Runtime::new().unwrap();
 	let mut group = c.benchmark_group("per_core_steady_state");
@@ -316,7 +333,7 @@ fn bench_per_core_steady_state(c: &mut Criterion) {
 	group.bench_function("per_core", |b| {
 		b.iter_custom(|iters| {
 			rt.block_on(async move {
-				let pool = Builder::new().thread_per_core(true).build();
+				let pool = per_core_pool();
 				let _ = pool.spawn(|| 0u32).await;
 				let mut total = Duration::ZERO;
 				let counter = Arc::new(AtomicUsize::new(0));

--- a/benches/threadpool.rs
+++ b/benches/threadpool.rs
@@ -18,6 +18,22 @@ fn cpu_task(iterations: usize) -> usize {
 	sum
 }
 
+/// Build a one-worker-per-core pool. Pinned when the `pinning` feature is
+/// enabled; otherwise an equivalent worker-per-core pool without pinning,
+/// so these benches compile and run either way (use `--features pinning`
+/// to measure the actual pinned config).
+fn per_core_pool() -> Threadpool {
+	#[cfg(feature = "pinning")]
+	{
+		Builder::new().with_affinity_pinning(true).build()
+	}
+	#[cfg(not(feature = "pinning"))]
+	{
+		let cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+		Threadpool::new(cores)
+	}
+}
+
 /// Benchmark basic threadpool operations with different worker counts
 fn bench_basic_operations(c: &mut Criterion) {
 	let rt = Runtime::new().unwrap();
@@ -184,7 +200,7 @@ fn bench_per_core_contention(c: &mut Criterion) {
 						let mut total_duration = Duration::from_nanos(0);
 
 						for _iter in 0..iters {
-							let pool = Builder::new().thread_per_core(true).build();
+							let pool = per_core_pool();
 							let counter = Arc::new(AtomicUsize::new(0));
 							let start = Instant::now();
 
@@ -288,7 +304,7 @@ fn bench_throughput_comparison(c: &mut Criterion) {
 				let mut total_duration = Duration::from_nanos(0);
 
 				for _iter in 0..iters {
-					let pool = Builder::new().thread_per_core(true).build();
+					let pool = per_core_pool();
 					let start = Instant::now();
 
 					let mut handles = Vec::with_capacity(THROUGHPUT_TASKS);
@@ -349,7 +365,7 @@ fn bench_task_latency(c: &mut Criterion) {
 	let configs = vec![
 		("single_worker", 1, false),
 		("four_workers", 4, false),
-		("per_core_affinity", 0, true), // 0 will be ignored when thread_per_core is true
+		("per_core_affinity", 0, true), // worker count ignored; per_core_pool() decides
 	];
 
 	for (name, workers, per_core) in configs {
@@ -360,7 +376,7 @@ fn bench_task_latency(c: &mut Criterion) {
 
 					for _iter in 0..iters {
 						let pool = if per_core {
-							Builder::new().thread_per_core(true).build()
+							per_core_pool()
 						} else {
 							Threadpool::new(workers)
 						};

--- a/src/affinity/linux.rs
+++ b/src/affinity/linux.rs
@@ -28,6 +28,13 @@ pub fn get_core_ids() -> Option<Vec<CoreId>> {
 }
 
 pub fn set_for_current(core_id: CoreId) -> bool {
+	// `CPU_SET` indexes `cpu_set_t::__bits[core_id.id / NBITS]`; an id at
+	// or beyond `CPU_SETSIZE` writes past the bitset (UB). Reject it up
+	// front rather than corrupt memory.
+	if core_id.id >= CPU_SETSIZE as usize {
+		return false;
+	}
+
 	// Turn `core_id` into a `libc::cpu_set_t` with only
 	// one core active.
 	let mut set = new_cpu_set();

--- a/src/affinity/macos.rs
+++ b/src/affinity/macos.rs
@@ -2,7 +2,7 @@
 
 use std::mem;
 
-use libc::{c_int, c_uint, pthread_self};
+use libc::{c_int, c_uint, pthread_mach_thread_np, pthread_self};
 
 use super::CoreId;
 
@@ -22,7 +22,13 @@ type thread_policy_t = *mut thread_affinity_policy_data_t;
 
 const THREAD_AFFINITY_POLICY: thread_policy_flavor_t = 4;
 const KERN_SUCCESS: kern_return_t = 0;
-const KERN_NOT_SUPPORTED: kern_return_t = 268435459;
+// `KERN_NOT_SUPPORTED` from `mach/kern_return.h`. Apple Silicon returns
+// this for `THREAD_AFFINITY_POLICY` (no hardware affinity support). The
+// previous value (268435459 = 0x10000003) was actually
+// `MACH_SEND_INVALID_DEST` — the symptom of passing a bogus thread port
+// (`pthread_self()` cast straight to `thread_t`), now fixed by routing
+// through `pthread_mach_thread_np`.
+const KERN_NOT_SUPPORTED: kern_return_t = 46;
 
 unsafe extern "C" {
 	fn thread_policy_set(
@@ -52,9 +58,13 @@ pub fn set_for_current(core_id: CoreId) -> bool {
 		affinity_tag: core_id.id as integer_t,
 	};
 
+	// `thread_policy_set` expects a mach thread port, NOT a `pthread_t`.
+	// Convert via `pthread_mach_thread_np`; casting `pthread_self()`
+	// (an opaque pointer) straight to `thread_t` yields a bogus port and
+	// silently fails on Intel.
 	let res = unsafe {
 		thread_policy_set(
-			pthread_self() as thread_t,
+			pthread_mach_thread_np(pthread_self()) as thread_t,
 			THREAD_AFFINITY_POLICY,
 			&mut info as thread_policy_t,
 			thread_affinity_policy_count,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,7 +11,10 @@ pub struct Builder {
 	num_threads: Option<usize>,
 	thread_name: Option<String>,
 	thread_stack_size: Option<usize>,
-	thread_per_core: bool,
+	/// One worker per core, each pinned to its core. Only settable via
+	/// [`Builder::with_affinity_pinning`] (the `pinning` feature); stays
+	/// `false` otherwise, so the default build never pins.
+	affinity_pinning: bool,
 }
 
 impl Builder {
@@ -27,7 +30,7 @@ impl Builder {
 			num_threads: None,
 			thread_name: None,
 			thread_stack_size: None,
-			thread_per_core: false,
+			affinity_pinning: false,
 		}
 	}
 
@@ -115,7 +118,15 @@ impl Builder {
 		self
 	}
 
-	/// Set whether a thread should be spawned per core.
+	/// Spawn one worker thread per CPU core and pin each worker to its
+	/// core. Requires the `pinning` crate feature.
+	///
+	/// Pinning is a best-effort hint: on platforms or hardware that do
+	/// not support thread affinity (e.g. Apple Silicon) the workers are
+	/// still spawned one-per-core but the pin is a no-op. Pinning helps
+	/// on bare-metal NUMA / latency-sensitive deployments; it is rarely
+	/// beneficial (and sometimes harmful) under containers or VMs where
+	/// "cores" are virtualised.
 	///
 	/// # Examples
 	///
@@ -123,7 +134,7 @@ impl Builder {
 	///
 	/// ```
 	/// let pool = affinitypool::Builder::new()
-	///     .thread_per_core(true)
+	///     .with_affinity_pinning(true)
 	///     .build();
 	///
 	/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -134,8 +145,9 @@ impl Builder {
 	///     }
 	/// # });
 	/// ```
-	pub fn thread_per_core(mut self, enabled: bool) -> Builder {
-		self.thread_per_core = enabled;
+	#[cfg(feature = "pinning")]
+	pub fn with_affinity_pinning(mut self, enabled: bool) -> Builder {
+		self.affinity_pinning = enabled;
 		self
 	}
 
@@ -153,7 +165,7 @@ impl Builder {
 		// Calculate how many threads to spawn.
 		let threads = if let Some(num_threads) = self.num_threads {
 			num_threads.clamp(1, MAX_THREADS)
-		} else if self.thread_per_core {
+		} else if self.affinity_pinning {
 			num_cpus::get().clamp(1, MAX_THREADS)
 		} else {
 			2
@@ -168,7 +180,7 @@ impl Builder {
 			thread_handles: Mutex::new(Vec::new()),
 		});
 		// Spawn the desired number of workers.
-		if self.thread_per_core {
+		if self.affinity_pinning {
 			for index in 0..threads {
 				Threadpool::spin_up(Some(index), data.clone(), index);
 			}

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,75 +1,49 @@
-//! Thread-local cached "current CPU" lookup for shard routing.
+//! Thread-local cached shard hint for producer→shard routing.
 //!
-//! Producers call [`current_cpu`] to pick a shard. The value is cached
-//! in thread-local state and only refreshed every [`REFRESH_EVERY`]
-//! calls — [`libc::sched_getcpu`] is a vDSO entry on modern Linux
-//! (≈5 ns) and `GetCurrentProcessorNumber` on Windows is similar, but
-//! the cached lookup is still a few cycles faster and avoids any
-//! syscall on platforms without a direct API.
+//! Producers call [`current_shard_hint`] to pick an injector shard. The
+//! hint is derived from the producer thread's ID, hashed once and cached
+//! for the lifetime of the thread — a thread's ID never changes, so there
+//! is nothing to refresh. The goal is purely that a given producer thread
+//! routes consistently to the same shard, which keeps that producer's
+//! traffic isolated to one injector and minimises cross-shard contention
+//! when many producers run concurrently (the dominant workload).
 //!
-//! Platforms without a direct "what CPU am I on" call fall back to
-//! hashing the thread ID. That loses geographical accuracy but
-//! preserves the goal: a given producer thread consistently routes
-//! to the same shard, which is what gets you cache locality for
-//! long-lived producers.
+//! This previously queried the running CPU (`sched_getcpu` on Linux,
+//! `GetCurrentProcessorNumber` on Windows) for geographic locality, but
+//! that bought little over thread-ID stickiness — workers steal across
+//! shards regardless — while costing a syscall/vDSO call and a platform
+//! dependency (`libc`/`winapi`). Hashing the thread ID is stable,
+//! allocation-free, identical on every target, and works under miri
+//! (which does not support `sched_getcpu`).
 
 use std::cell::Cell;
 
-/// Refresh cadence. Picked empirically: small enough that producer
-/// migrations don't strand a sender on a stale shard for long, large
-/// enough that the per-call overhead is amortised into the noise.
-const REFRESH_EVERY: u32 = 64;
-
 thread_local! {
-	/// `(cached_cpu, age)`. `age == REFRESH_EVERY` (or above) signals
-	/// "refresh on next call". Initialised so the very first call
-	/// always queries — that way we don't pay the cost of a query on
-	/// threads that never reach `current_cpu`.
-	static CACHED: Cell<(usize, u32)> = const { Cell::new((0, REFRESH_EVERY)) };
+	/// Cached shard hint for this thread, computed lazily on first use.
+	/// `None` until the first call; a thread's ID is immutable, so the
+	/// value never needs refreshing once set. Initialised lazily so
+	/// threads that never produce work pay nothing.
+	static SHARD_HINT: Cell<Option<usize>> = const { Cell::new(None) };
 }
 
-/// Return a stable hint for this thread's current CPU. The value is
-/// refreshed every [`REFRESH_EVERY`] calls; in between, callers see
-/// the cached result.
+/// Return a stable shard hint for the calling thread. Derived once from
+/// the thread ID and cached for the thread's lifetime.
 #[inline]
-pub(crate) fn current_cpu() -> usize {
-	CACHED.with(|c| {
-		let (cpu, age) = c.get();
-		if age >= REFRESH_EVERY {
-			let fresh = query_cpu();
-			c.set((fresh, 0));
-			fresh
-		} else {
-			c.set((cpu, age + 1));
-			cpu
+pub(crate) fn current_shard_hint() -> usize {
+	SHARD_HINT.with(|c| match c.get() {
+		Some(h) => h,
+		None => {
+			let h = hash_thread_id();
+			c.set(Some(h));
+			h
 		}
 	})
 }
 
-#[cfg(target_os = "linux")]
+/// Hash the current thread's `ThreadId` into a `usize`. Stable per
+/// thread, so a given producer always routes to the same shard.
 #[inline]
-fn query_cpu() -> usize {
-	// vDSO on modern Linux; ~5 ns.
-	let cpu = unsafe { libc::sched_getcpu() };
-	if cpu < 0 {
-		0
-	} else {
-		cpu as usize
-	}
-}
-
-#[cfg(target_os = "windows")]
-#[inline]
-fn query_cpu() -> usize {
-	use winapi::um::processthreadsapi::GetCurrentProcessorNumber;
-	unsafe { GetCurrentProcessorNumber() as usize }
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
-#[inline]
-fn query_cpu() -> usize {
-	// Fallback: hash the thread ID. Stable per producer thread, so we
-	// still get producer→shard affinity (just not CPU-locality based).
+fn hash_thread_id() -> usize {
 	use std::collections::hash_map::DefaultHasher;
 	use std::hash::{Hash, Hasher};
 	let mut h = DefaultHasher::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "pinning")]
 pub mod affinity;
 mod builder;
 mod cpu;
@@ -261,7 +262,10 @@ impl Threadpool {
 		let data_clone = data.clone();
 		// Spawn a new worker thread.
 		let handle = builder.spawn(move || {
-			// Assign this thread to a core.
+			// Assign this thread to a core (only when the `pinning`
+			// feature is enabled; otherwise `coreid` is always `None`
+			// and pinning is compiled out entirely).
+			#[cfg(feature = "pinning")]
 			if let Some(coreid) = coreid {
 				affinity::set_for_current(coreid.into());
 			}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -345,7 +345,7 @@ impl Queue {
 		if self.mask == 0 {
 			self.injectors[0].push(runnable);
 		} else {
-			let preferred = cpu::current_cpu() & self.mask;
+			let preferred = cpu::current_shard_hint() & self.mask;
 			let target = SPILL.with(|s| {
 				let (last, count) = s.get();
 				let new_count = if last == preferred {


### PR DESCRIPTION
**PR1 of the scheduling rework** — mechanical only, no change to the queue's lost-wakeup handshake. Sets up a clean, safe default build so the correctness-sensitive scheduling work (per-worker parking, spin-before-park, randomized stealing) can land separately.

## Why

CPU pinning is off by default, off in every benchmark, and is ~600 lines of multi-platform `unsafe` FFI that also carried two latent bugs. It earns its keep only on bare-metal NUMA / latency-SLA deployments (e.g. SurrealDB's per-core config), so it should be **opt-in**, not deleted — and the default build should carry none of it.

## What changed

- **`pinning` cargo feature (off by default).** The `affinity` module and the `libc`/`winapi` FFI are gated behind it (both are now optional deps). The default build compiles no pinning `unsafe` code.
- **`Builder::thread_per_core(bool)` → `Builder::with_affinity_pinning(bool)`**, behind `pinning`. *(Breaking; pre-1.0.)*
- **Routing no longer queries the CPU.** Producers pick a shard from a cached thread-ID hash instead of `sched_getcpu()` / `GetCurrentProcessorNumber()`. Drops a per-push syscall/vDSO call, removes `libc`/`winapi` from the default build, and fixes routing under miri. Per-producer shard stickiness is unchanged.
- **Two latent affinity bugs fixed** (only reachable with `pinning`):
  - Linux: `set_for_current` called `CPU_SET` with no bounds check — UB for `core_id >= CPU_SETSIZE`. Now rejected.
  - macOS: passed a `pthread_t` straight to `thread_policy_set` (wants a mach port) → silent no-op on Intel; and the `KERN_NOT_SUPPORTED` constant was mislabeled (`0x10000003` is actually `MACH_SEND_INVALID_DEST`, the symptom of that bogus port). Now routes through `pthread_mach_thread_np` and matches the correct `KERN_NOT_SUPPORTED` (46).
- **CI**: added default-feature `test` + `clippy` runs (the default build was previously never tested); benches now compile under `--all-features`.
- **Benches**: feature-gated `per_core_pool()` helper so the per-core benches run with or without `pinning`.

## Verification

| Gate | default | `--all-features` |
|---|---|---|
| build | ✅ (no `libc`/`winapi`) | ✅ |
| clippy `-D warnings` | ✅ | ✅ |
| test | ✅ 37 + 5 doctests | ✅ 37 + 7 doctests |
| miri `--lib` | ✅ | — |
| fmt · benches `--no-run` · loom | ✅ · ✅ · ✅ (4 models) | |

## Note (pre-existing, not from this PR)

`async_task_smoke::cancel_await_resolves_after_runnable_stops` is a seed-dependent miri flake — it waits for a worker thread with `thread::sleep` then asserts. Confirmed it fails identically on `main` with my changes stashed, and it touches no affinitypool code. Worth hardening separately (signal readiness via a channel instead of a sleep).