### PR TITLE
fix: wake parked peers on self-spawn (fixes a pool deadlock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,20 +44,35 @@
   platform dependency, and it works under miri; per-producer shard
   stickiness is unchanged.
 
+### Fixed
+
+- **Deadlock when a worker blocked on its own self-spawned runnable.**
+  The self-spawn fast path (a `pool.spawn(..)` from inside a worker
+  closure, which pushes into that worker's own deque) issued no wake to
+  parked peers, on the reasoning that the spawning worker is also the
+  consumer. That reasoning does not hold: a worker that polls a
+  `SpawnFuture` and then drops it runs `block_on_cancel` ->
+  `thread::park()`, blocking until the runnable it just queued has
+  stopped. That runnable is in the blocked worker's own deque, so only
+  a peer steal can complete it — and with every peer parked and no
+  wake issued, nothing ever woke them. The pool hung indefinitely.
+  The self-spawn path now performs the same fenced wake handshake as a
+  foreign push (`fence(SeqCst)` then the `parked` check — a `Relaxed`
+  peek would be unsound, since x86-TSO alone lets the store-then-load
+  pair be observed out of order). A one-worker pool has no peer to
+  wake and still self-deadlocks on that pattern; that is inherent and
+  is now documented on `Threadpool::spawn_local`.
+
 ### Behavioural notes
 
 - **Worker self-spawn fast path.** When a closure running on a
   worker thread calls `pool.spawn(...)`, the new task is pushed
   directly into that worker's own local deque instead of routing
-  through the shared injector. The producer (this thread) is also
-  the consumer, so no cross-thread wake is issued — *other workers
-  currently parked stay parked*. This is intentional and almost
-  always what you want (it saves the wake roundtrip), but a
-  workload that fans out **only** via self-spawn cascades, with no
-  external producer to wake parked peers, will serialise on the
-  spawning worker until something else wakes them. The spawning
-  worker's local deque is still a stealer target, so peers that
-  wake on a later foreign push will recover the imbalance.
+  through the shared injector, so work stays biased toward the
+  spawning worker (good for locality) while remaining visible to peer
+  stealers. Unlike earlier releases it now also wakes a parked peer;
+  see the fix above for why that is required rather than merely
+  desirable.
 
 ## 0.6.0 — 2026-05-24 — async-task rewrite + sharded queue
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ Shard count rules of thumb:
 
 ### Behaviour notes
 
-**Worker self-spawn fast path.** When a closure running on a worker thread calls `pool.spawn(...)`, the new task is pushed directly into that worker's own local deque instead of routing through the shared sharded queue. The producer (this thread) is also the consumer, so no cross-thread wake is issued — *other workers currently parked stay parked*. This is intentional and saves a wake roundtrip, but a workload that fans out **only** via self-spawn cascades with no external producer to wake parked peers will serialise on the spawning worker until something else wakes them. The spawning worker's local deque is still a stealer target, so peers that wake on a later foreign push will recover the imbalance.
+**Worker self-spawn fast path.** When a closure running on a worker thread calls `pool.spawn(...)`, the new task is pushed directly into that worker's own local deque instead of routing through the shared sharded queue, skipping the shard routing. The spawning worker is usually also the consumer — it returns to its pop loop and drains its own deque — so the work stays biased toward that worker, which is what you want for cache locality.
+
+It still issues the same wake handshake a foreign push does, because the spawning worker is *not guaranteed* to reach its pop loop: a worker that polls a `SpawnFuture` and then drops it blocks in the drop, waiting for the very runnable it just queued. That runnable is in the blocked worker's own deque, so only a peer steal can complete it — the spawning worker's deque is a stealer target. Skipping the wake there let the pool hang until the blocked worker gave up, which is forever. On a one-worker pool there is no peer to wake, so that pattern self-deadlocks regardless; see the `Threadpool::spawn_local` docs.
 
 #### Original
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,15 @@ impl Threadpool {
 	///    `let _ = pool.spawn_local(|| …);` from inside its own
 	///    worker. Polling once and *then* dropping still queues and
 	///    cancels normally.
+	/// 3. **A one-worker pool cannot cancel its own work.** Polling a
+	///    `SpawnFuture` and then dropping it *from inside the pool's
+	///    only worker* deadlocks that worker: the poll queues the
+	///    runnable onto the worker's own deque, and the drop then
+	///    blocks waiting for that runnable to stop, which only this
+	///    worker (or a peer, of which there are none) could make
+	///    happen. On a pool with two or more workers the queued
+	///    runnable is stolen by a peer — the self-spawn path wakes one
+	///    — and the drop completes.
 	///
 	/// # Safety
 	///

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -297,21 +297,29 @@ impl Queue {
 		// Self-spawn fast path: if the calling thread is itself
 		// a worker for THIS queue (set via `enter_worker_scope`
 		// during worker startup), push directly into that
-		// worker's local deque and skip the Injector + fence +
-		// parked check entirely.
+		// worker's local deque, skipping the Injector and the
+		// shard routing.
 		//
-		// Producer and consumer are the same thread, so no
-		// cross-thread synchronisation is needed for visibility:
-		// the worker's next `pop_blocking` is sequenced-after
-		// this `push` in program order and will see the new
-		// runnable via `ctx.deque.pop()`.
+		// The spawning worker is *usually* also the consumer — it
+		// returns to `pop_blocking` and pops its own deque, which
+		// needs no cross-thread synchronisation. But it is not
+		// guaranteed to get there: a worker that polls a
+		// `SpawnFuture` and then drops it runs
+		// `SpawnFuture::drop` -> `block_on_cancel` ->
+		// `thread::park()`, which blocks until that very runnable
+		// has run or been dropped. The runnable is sitting in this
+		// worker's own deque, so the worker can no longer reach it
+		// and only a *peer steal* can make progress. If every peer
+		// is parked and we skip the wake, nothing ever wakes them:
+		// the pool deadlocks for as long as the blocked worker
+		// waits, which is forever.
 		//
-		// Side effect: any *other* workers currently parked stay
-		// parked. They'll wake on the next foreign push via the
-		// slow path below. For self-spawn cascades the work
-		// stays biased toward the spawning worker, but is still
-		// visible to peer stealers (the local deque is also a
-		// stealer target).
+		// So the local deque is published with the same fenced
+		// handshake the foreign path uses. The Dekker argument is
+		// unchanged in shape — it only needs the producer's queue
+		// access and the worker's steal to touch the same object —
+		// with `Worker::push` and `Stealer::steal_batch_and_pop`
+		// on this deque taking the place of the injector pair.
 		if let Some(handle) = CURRENT_WORKER.with(|w| w.get())
 			&& std::ptr::eq(handle.queue.as_ptr().cast_const(), self as *const Queue)
 		{
@@ -328,6 +336,22 @@ impl Queue {
 			// is sound.
 			unsafe {
 				handle.deque.as_ref().push(runnable);
+			}
+			// Same fence + parked check as the foreign path below.
+			// A `Relaxed` peek at `parked` would not do: without the
+			// fence, x86-TSO alone permits this store-then-load pair
+			// to be observed out of order, so we could read
+			// `parked == 0` while a peer that is about to sleep has
+			// already missed our push.
+			//
+			// A 1-worker pool has no peer to wake, so a worker that
+			// blocks on its own self-spawned runnable there still
+			// deadlocks; that is inherent, and documented on
+			// `Threadpool::spawn_local`.
+			fence(Ordering::SeqCst);
+			if self.parked.load(Ordering::Acquire) > 0 {
+				let _g = self.park.lock();
+				self.notify.notify_one();
 			}
 			return;
 		}

--- a/tests/self_spawn_wakeup.rs
+++ b/tests/self_spawn_wakeup.rs
@@ -1,0 +1,108 @@
+//! Regression tests for the self-spawn wake-up handshake.
+//!
+//! A worker that pushes into its own deque is normally also the
+//! consumer, but it can block before returning to its pop loop — a
+//! polled-then-dropped [`affinitypool::SpawnFuture`] runs
+//! `block_on_cancel` -> `thread::park()`, waiting for the very runnable
+//! it just queued. At that point only a peer steal can make progress,
+//! so the self-spawn path has to wake a parked peer. It previously did
+//! not, and the pool hung.
+#![cfg(not(loom))]
+
+use affinitypool::Threadpool;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::mpsc;
+use std::task::{Context, Waker};
+use std::thread;
+use std::time::Duration;
+
+/// Poll a `SpawnFuture` exactly once (which schedules it) and then drop
+/// it, from inside a worker of the same pool. Polling is what puts the
+/// runnable on the queue; dropping then blocks this worker until that
+/// runnable stops. With every peer parked, only a wake from the
+/// self-spawn path can free it.
+///
+/// Run on a helper thread with a bounded `recv_timeout` so a regression
+/// fails the test instead of hanging CI.
+#[test]
+fn self_spawn_wakes_parked_peer_when_spawner_blocks() {
+	let (done_tx, done_rx) = mpsc::channel::<()>();
+
+	let worker = thread::spawn(move || {
+		let pool = Arc::new(Threadpool::new(2));
+		let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+
+		// Warm both workers, then let them settle into a park so the
+		// peer really is asleep when the self-spawn happens.
+		rt.block_on(async {
+			let _ = pool.spawn(|| 0u32).await;
+		});
+		thread::sleep(Duration::from_millis(100));
+
+		let inner = pool.clone();
+		// A foreign push: wakes exactly one worker to run this closure.
+		let outer = pool.spawn(move || {
+			// On a worker of `inner` now, so this takes the self-spawn
+			// path on first poll: the runnable lands in *this* worker's
+			// own deque.
+			// SAFETY: polled and dropped within this closure, never
+			// leaked, and the closure borrows nothing non-'static.
+			let fut = unsafe { inner.spawn_local(|| 42u32) };
+			let mut fut = Box::pin(fut);
+			let mut cx = Context::from_waker(Waker::noop());
+			let _ = fut.as_mut().poll(&mut cx);
+			// Dropping while scheduled blocks this worker until the
+			// runnable it just queued has stopped.
+			drop(fut);
+		});
+
+		rt.block_on(outer);
+		let _ = done_tx.send(());
+	});
+
+	assert!(
+		done_rx.recv_timeout(Duration::from_secs(10)).is_ok(),
+		"deadlock: a self-spawned runnable was stranded in the deque of a \
+		 worker that then blocked, while its peer stayed parked"
+	);
+	worker.join().unwrap();
+}
+
+/// The same shape, but the self-spawned work is awaited normally rather
+/// than cancelled. This is the common case and must keep working: the
+/// spawning worker consumes its own deque.
+#[test]
+fn self_spawn_still_runs_on_spawning_worker() {
+	let (done_tx, done_rx) = mpsc::channel::<u32>();
+
+	let worker = thread::spawn(move || {
+		let pool = Arc::new(Threadpool::new(2));
+		let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+		let inner = pool.clone();
+
+		type Inner = Pin<Box<dyn Future<Output = u32> + Send>>;
+		let (tx, rx) = mpsc::channel::<Inner>();
+
+		let outer = pool.spawn(move || {
+			// Self-spawn, then hand the future out to be awaited off
+			// the worker so this closure can return normally.
+			let f: Inner = Box::pin(inner.spawn(|| 42u32));
+			tx.send(f).unwrap();
+		});
+
+		rt.block_on(async {
+			outer.await;
+			let f = rx.recv_timeout(Duration::from_secs(5)).expect("no inner future");
+			let _ = done_tx.send(f.await);
+		});
+	});
+
+	assert_eq!(
+		done_rx.recv_timeout(Duration::from_secs(10)).ok(),
+		Some(42),
+		"self-spawned runnable did not complete"
+	);
+	worker.join().unwrap();
+}


### PR DESCRIPTION
Fixes a **reproducible deadlock** in the current `main`. Found while adversarially reviewing the design for the scheduling rework — the review refuted an assumption that turned out to be load-bearing in already-shipped code.

## The bug

A `pool.spawn(..)` from inside a worker closure takes the self-spawn fast path: the runnable goes straight into that worker's own deque. That path issued **no wake to parked peers**, justified in a comment by *"the producer is also the consumer, so no cross-thread wake is needed"*.

That justification is false. A worker that polls a `SpawnFuture` and then drops it runs `SpawnFuture::drop` → `block_on_cancel` → `thread::park()`, which blocks until the runnable it just queued has run or been dropped. But that runnable is in the now-blocked worker's **own deque** — the worker can't reach it, so only a peer steal can make progress. With every peer parked and no wake issued, nothing ever wakes them. The pool hangs indefinitely.

Not theoretical: `tests/self_spawn_wakeup.rs` reproduces it. Verified it hangs (10s timeout) on unmodified `9eaf52a` and passes with this fix; the accompanying control test (normal self-spawn, awaited rather than cancelled) passes both ways, so the test is specific to the blocked-spawner case and not vacuous.

## The fix

The self-spawn path now performs the same fenced handshake as a foreign push — `fence(SeqCst)` then the `parked` check under the park mutex.

The fence is required, not decorative: a `Relaxed` peek at `parked` would let x86-TSO observe the deque store and the `parked` load out of order, so we could read `parked == 0` while a peer that is about to sleep has already missed the push. The existing Dekker argument carries over unchanged in shape, with `Worker::push` / `Stealer::steal_batch_and_pop` on the local deque taking the place of the injector pair.

**Known limitation, now documented:** a one-worker pool has no peer to wake, so polling-then-dropping a `SpawnFuture` from inside the only worker still self-deadlocks. That's inherent (the work can only be run by the thread that is blocking on it) and is documented on `Threadpool::spawn_local` beside the existing drop-blocking caveats.

## Performance

The fence sits inside the self-spawn branch only — the foreign-producer path is untouched — and no benchmark in the suite exercises self-spawn (they all push from a foreign producer), so this is off every measured hot path. I'm deliberately not quoting a before/after delta: the runs I have aren't a valid A/B (different bench scope, hence different thermal/load conditions).

## Verification

`cargo test` (all suites incl. the 2 new tests) · `clippy --all-targets -D warnings` · `fmt` · `loom` (4 models) · `miri --lib` — all green locally.

Docs: the README's "Worker self-spawn fast path" section and the CHANGELOG both described the old "parked peers stay parked" behaviour as intentional; both updated.