### PR TITLE
perf: stop idle workers thrashing the steal path; spin before parking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,48 +20,72 @@
   picked up without a futex round-trip. The `yield_now` rounds matter
   for oversubscribed pools, where a purely spinning worker starves
   the producer it is waiting for.
+- **The pre-park scan no longer walks the whole pool.** A worker's
+  unarmed scans now inspect at most `CHEAP_SCAN_VICTIMS` injectors and
+  peers per pass, and read each peer's stealer slot with
+  `ArcSwapOption::load` rather than `load_full` — the latter clones the
+  `Arc`, and that refcount is a cache line every idle worker was
+  touching on every pass. The scan a worker performs immediately before
+  it parks is still exhaustive, because that sweep is what the
+  lost-wakeup proof rests on. Measured on the 64-thread box with each
+  side run twice (both stable to 2%): a submit-and-await round trip
+  costs 1.77x less at 64 workers, 1.58x at 256 and 1.43x at 512, and is
+  unchanged at or below 8 workers. Pools of that size were previously
+  untested — the suite stopped at 8 workers, so
+  `park_unpark_handshake` now runs up to `MAX_THREADS` to keep this
+  honest. Note the remaining growth with pool size (~50x from 8 to 512
+  workers) is that final exhaustive sweep and cannot be bounded without
+  giving up the proof.
 - **Faster producer spill.** `SPILL_THRESHOLD` drops from 32 to 8, so
   a single producer fanning out spreads across shards sooner instead
   of piling onto one while the other workers idle.
 
 Measured on an idle AMD Ryzen Threadripper 9970X (32 cores / 64 threads,
-one NUMA node), Ubuntu 24.04, kernel 6.8, full criterion sampling. All
-three revisions were benchmarked back-to-back in one session on a machine
-at load average 0.00, with rayon built from the same runs as an unchanged
-control. Every figure below has non-overlapping criterion confidence
-intervals (median CI width 11%).
+one NUMA node), Ubuntu 24.04, kernel 6.8, full criterion sampling, all
+revisions benchmarked back-to-back at load average 0.00.
+
+**Read the multipliers as approximate.** A repeat run of identical code
+on that machine moved 8 of 30 workloads by more than 20%, and
+`per_core_steady_state` by 1.6x. Criterion's confidence intervals only
+describe sampling variance *within* one run; they say nothing about
+run-to-run reproducibility, and the two are far apart for anything
+involving several workers racing to steal. The effects below are 3-7x, an
+order of magnitude larger than that drift, so their direction and rough
+size are solid — their third significant figure is not.
 
 **24 of 27 microbenchmarks faster, 3 slower.**
 
-| workload | 0.7.0 + prior fixes | this release | |
+| workload | 0.7.0 + prior fixes | this release | approx |
 |---|---|---|---|
-| `steal_imbalance/8_workers` | 25.4 ms | 3.64 ms | 6.98x |
-| `spawn_overhead/4_workers/1` | 6.14 us | 1.11 us | 5.51x |
-| `steady_state_busy/8_workers` | 98.2 ms | 17.9 ms | 5.49x |
-| `park_unpark_handshake/4_workers` | 5.83 us | 1.09 us | 5.32x |
-| `spawn_overhead/1_worker/1` | 5.37 us | 1.17 us | 4.60x |
-| `spawn_local_overhead/4_workers/1000` | 4.87 ms | 1.09 ms | 4.46x |
-| `steady_state_busy/4_workers` | 18.2 ms | 4.47 ms | 4.07x |
-| `steal_imbalance/2_workers` | 9.33 ms | 2.46 ms | 3.80x |
-| `steal_imbalance/4_workers` | 10.7 ms | 3.25 ms | 3.30x |
-| `multi_producer_contention/2p_4w` | 2.66 ms | 878 us | 3.02x |
-| `per_core_steady_state` (64 workers) | 203 ms | 74.2 ms | 2.74x |
-| `multi_producer_contention/4p_1w` | 802 us | 999 us | 0.80x |
-| `multi_producer_contention/2p_1w` | 436 us | 511 us | 0.85x |
-| `multi_producer_contention/8p_1w` | 1.88 ms | 2.22 ms | 0.85x |
+| `steal_imbalance/8_workers` | 25 ms | 3.6 ms | ~7x |
+| `steady_state_busy/8_workers` | 98 ms | 18 ms | ~5x |
+| `spawn_overhead/4_workers/1` | 6.1 us | 1.1 us | ~5x |
+| `park_unpark_handshake/4_workers` | 5.8 us | 1.1 us | ~5x |
+| `spawn_overhead/1_worker/1` | 5.4 us | 1.2 us | ~4x |
+| `spawn_local_overhead/4_workers/1000` | 4.9 ms | 1.1 ms | ~4x |
+| `steady_state_busy/4_workers` | 18 ms | 4.5 ms | ~4x |
+| `steal_imbalance/2_workers` | 9.3 ms | 2.5 ms | ~4x |
+| `steal_imbalance/4_workers` | 11 ms | 3.3 ms | ~3x |
+| `multi_producer_contention/2p_4w` | 2.7 ms | 0.88 ms | ~3x |
+| `per_core_steady_state` (64 workers) | 203 ms | 74-142 ms | ~1.5-2.7x |
+| `multi_producer_contention/4p_1w` | 802 us | 999 us | ~0.8x |
+| `multi_producer_contention/2p_1w` | 436 us | 511 us | ~0.85x |
+| `multi_producer_contention/8p_1w` | 1.9 ms | 2.2 ms | ~0.85x |
 
-The three regressions share a shape: one worker fed by several
-producers, so the worker is saturated and the pre-park backoff is pure
-delay before a park it was always going to take.
+`per_core_steady_state` is given as a range because it is the least
+reproducible workload in the suite; the three regressions all share one
+shape, a single worker fed by several producers, where the worker is
+saturated and the pre-park backoff is delay before a park it was always
+going to take.
 
-Against `rayon::ThreadPool::spawn` on the same machine and runs,
-affinitypool is now ahead on 14 of 17 head-to-head workloads, including
-`multi_producer/4p_4w` (475 us vs 1.08 ms) and `spawn_overhead/4w/10000`
-(1.99 ms vs 3.46 ms). The remaining three are within noise or close:
-`round_trip/1` 1.07 us vs 0.94 us, `round_trip/8` 2.00 us vs 1.91 us
-(neither statistically separable), and `spawn_overhead/1w/100` 21.8 us vs
-19.6 us. Earlier releases lost single-task latency to rayon by 4-6x on
-this platform; the pre-park backoff closes that.
+Against `rayon::ThreadPool::spawn` on the same machine, affinitypool is
+ahead on 14 of 17 head-to-head workloads. The notable change is
+single-task latency: earlier releases lost to rayon by 4-6x on this
+platform (`round_trip/1` 4.4 us vs 0.94 us), and the pre-park backoff
+closes that to a statistical tie (1.07 us vs 0.94 us), with
+`spawn_overhead/1w/1` slightly ahead at 0.98 us vs 1.00 us. Those
+single-task rows are among the *most* reproducible in the suite, drifting
+under 7% between runs.
 
 One caveat worth stating: these gains assume spare CPU. On a
 CPU-contended host a spinning worker competes with the producer it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+### Performance
+
+- **Idle workers no longer thrash the queue.** An idle multi-worker
+  pool used to burn itself on the steal path: every worker walked
+  victims in the same order, hammered a contended
+  `steal_batch_and_pop` CAS, and spun in place on `Steal::Retry`.
+  Three changes — a per-worker random start offset for the
+  cross-shard and peer-steal walks, an `is_empty()` probe before each
+  steal on the unarmed scans (a shared load instead of a failed CAS),
+  and moving on to the next victim on `Retry` instead of spinning on
+  the contended one — turn that storm back into useful work. Measured
+  on an M2 Max (12 cores, `--quick`): `steal_imbalance/8_workers`
+  41.3 ms → 5.5 ms (7.4×), `steady_state_busy/8_workers`
+  114.9 ms → 17.4 ms (6.6×), `per_core_steady_state` 91.2 ms →
+  19.6 ms (4.7×). Adding workers no longer makes the pool slower.
+- **Bounded spin before parking.** A worker now re-scans a few times
+  with `spin_loop` backoff and then a few more with `yield_now`
+  before it arms and parks, so a runnable already on its way is
+  picked up without a futex round-trip. The `yield_now` rounds matter
+  for oversubscribed pools, where a purely spinning worker starves
+  the producer it is waiting for. Single-task latency:
+  `park_unpark_handshake/1_worker` 7.2 µs → 5.1 µs,
+  `spawn_overhead/4_workers/1` 8.1 µs → 5.5 µs.
+- **Faster producer spill.** `SPILL_THRESHOLD` drops from 32 to 8, so
+  a single producer fanning out spreads across shards sooner instead
+  of piling onto one while the other workers idle.
+- Net effect versus 0.7.0 on the microbenchmark suite: faster on 17 of
+  18 workloads, the exception being `steal_imbalance/2_workers`
+  (1.31 ms → 1.70 ms), where the pre-park backoff costs more than it
+  recovers. Numbers are from one machine and one OS; treat them as
+  directional.
+
+### Added
+
+- **`Builder::shards(n)`** to override how many queue shards producers
+  distribute work across (default: one per worker, capped at 8). More
+  shards means less contention between concurrent producers but more
+  empty queues for an idle worker to scan. Rounded up to a power of
+  two and clamped to at most one shard per worker.
+
 ### Breaking changes
 
 - **`spawn_local` is now `unsafe`.** Both `Threadpool::spawn_local` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,51 @@
   a single producer fanning out spreads across shards sooner instead
   of piling onto one while the other workers idle.
 
-**No performance figures are quoted here yet.** The changes above are
-motivated by a real, reproducible pathology — before them, a pool got
-*slower* when given more workers for identical work — but every
-measurement taken so far came from a developer laptop that was not
-quiet (load average ~7.6 on 12 cores, a browser holding ~1.5 of them).
-These benchmarks are unusually sensitive to exactly that: the mechanism
-being changed *is* the competition between idle workers and the producer
-for CPU, so background load moves the multi-worker rows by up to 7x
-between runs of identical code. Numbers taken under those conditions
-would be misleading whichever direction they pointed, so they have been
-left out until the suite can be run on an idle machine — ideally the
-Linux target this pool is deployed on.
+Measured on an idle AMD Ryzen Threadripper 9970X (32 cores / 64 threads,
+one NUMA node), Ubuntu 24.04, kernel 6.8, full criterion sampling. All
+three revisions were benchmarked back-to-back in one session on a machine
+at load average 0.00, with rayon built from the same runs as an unchanged
+control. Every figure below has non-overlapping criterion confidence
+intervals (median CI width 11%).
+
+**24 of 27 microbenchmarks faster, 3 slower.**
+
+| workload | 0.7.0 + prior fixes | this release | |
+|---|---|---|---|
+| `steal_imbalance/8_workers` | 25.4 ms | 3.64 ms | 6.98x |
+| `spawn_overhead/4_workers/1` | 6.14 us | 1.11 us | 5.51x |
+| `steady_state_busy/8_workers` | 98.2 ms | 17.9 ms | 5.49x |
+| `park_unpark_handshake/4_workers` | 5.83 us | 1.09 us | 5.32x |
+| `spawn_overhead/1_worker/1` | 5.37 us | 1.17 us | 4.60x |
+| `spawn_local_overhead/4_workers/1000` | 4.87 ms | 1.09 ms | 4.46x |
+| `steady_state_busy/4_workers` | 18.2 ms | 4.47 ms | 4.07x |
+| `steal_imbalance/2_workers` | 9.33 ms | 2.46 ms | 3.80x |
+| `steal_imbalance/4_workers` | 10.7 ms | 3.25 ms | 3.30x |
+| `multi_producer_contention/2p_4w` | 2.66 ms | 878 us | 3.02x |
+| `per_core_steady_state` (64 workers) | 203 ms | 74.2 ms | 2.74x |
+| `multi_producer_contention/4p_1w` | 802 us | 999 us | 0.80x |
+| `multi_producer_contention/2p_1w` | 436 us | 511 us | 0.85x |
+| `multi_producer_contention/8p_1w` | 1.88 ms | 2.22 ms | 0.85x |
+
+The three regressions share a shape: one worker fed by several
+producers, so the worker is saturated and the pre-park backoff is pure
+delay before a park it was always going to take.
+
+Against `rayon::ThreadPool::spawn` on the same machine and runs,
+affinitypool is now ahead on 14 of 17 head-to-head workloads, including
+`multi_producer/4p_4w` (475 us vs 1.08 ms) and `spawn_overhead/4w/10000`
+(1.99 ms vs 3.46 ms). The remaining three are within noise or close:
+`round_trip/1` 1.07 us vs 0.94 us, `round_trip/8` 2.00 us vs 1.91 us
+(neither statistically separable), and `spawn_overhead/1w/100` 21.8 us vs
+19.6 us. Earlier releases lost single-task latency to rayon by 4-6x on
+this platform; the pre-park backoff closes that.
+
+One caveat worth stating: these gains assume spare CPU. On a
+CPU-contended host a spinning worker competes with the producer it is
+waiting for, and an earlier revision of this work measured the opposite
+sign on a loaded laptop. The backoff yields as well as spins to limit
+that, but a heavily oversubscribed deployment should measure rather than
+assume.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,45 +24,18 @@
   a single producer fanning out spreads across shards sooner instead
   of piling onto one while the other workers idle.
 
-Measured against 0.7.0 on one M2 Max (8P+4E), macOS, criterion
-`--quick`, both revisions benchmarked back-to-back in one session.
-**Read these with the noise floor in mind:** rayon's numbers are
-included in the same runs as an unchanged control, and they varied by a
-median of 14.5% (max 32.6%) between runs, so a delta under ~15% here is
-not a signal.
-
-| workload | 0.7.0 | now | |
-|---|---|---|---|
-| `steady_state_busy/8_workers` | 105.8 ms | 16.0 ms | 6.6× |
-| `steal_imbalance/8_workers` | 31.9 ms | 5.0 ms | 6.3× |
-| `per_core_steady_state` | 78.8 ms | 18.6 ms | 4.25× |
-| `multi_producer_contention/4p_4w` | 1.56 ms | 0.89 ms | 1.75× |
-| `multi_producer_contention/2p_4w` | 1.01 ms | 0.58 ms | 1.75× |
-| `steal_imbalance/4_workers` | 5.81 ms | 3.54 ms | 1.64× |
-| `spawn_overhead/4_workers/10000` | 5.29 ms | 3.64 ms | 1.45× |
-| `spawn_overhead/4_workers/100` | 47.2 µs | 32.8 µs | 1.44× |
-| `multi_producer_contention/8p_4w` | 2.26 ms | 1.57 ms | 1.44× |
-| `spawn_overhead/4_workers/1000` | 462 µs | 322 µs | 1.43× |
-| `steady_state_busy/4_workers` | 8.05 ms | 5.88 ms | 1.37× |
-| `steal_imbalance/2_workers` | 894 µs | 1.49 ms | **0.60×** |
-| `park_unpark_handshake/8_workers` | 5.17 µs | 6.27 µs | **0.82×** |
-
-Every gain is at four workers or more; the single- and two-worker
-workloads land inside the noise band or slightly worse. So this is a
-**multi-worker scaling fix, not a single-task latency improvement** —
-`park_unpark_handshake` and the 1-worker `spawn_overhead` rows are flat
-within noise. The two real regressions are `steal_imbalance/2_workers`
-(67% slower) and `park_unpark_handshake/8_workers` (21% slower), where
-the pre-park backoff costs more than it recovers.
-
-Against rayon on the same machine and runs, affinitypool is now ahead on
-15 of 17 head-to-head workloads (`round_trip/8` 5.6 µs vs 13.8 µs;
-`round_trip/4` 5.2 µs vs 8.5 µs). rayon still leads the two
-single-task/one-worker cases (`round_trip/1` 5.05 µs vs 4.08 µs;
-`spawn_overhead/1w/1` 4.91 µs vs 3.54 µs). Note the "rayon wins
-single-task latency by 3–6×" table in the README was produced on Linux
-and does not reproduce here — treat all of this as directional for
-another OS.
+**No performance figures are quoted here yet.** The changes above are
+motivated by a real, reproducible pathology — before them, a pool got
+*slower* when given more workers for identical work — but every
+measurement taken so far came from a developer laptop that was not
+quiet (load average ~7.6 on 12 cores, a browser holding ~1.5 of them).
+These benchmarks are unusually sensitive to exactly that: the mechanism
+being changed *is* the competition between idle workers and the producer
+for CPU, so background load moves the multi-worker rows by up to 7x
+between runs of identical code. Numbers taken under those conditions
+would be misleading whichever direction they pointed, so they have been
+left out until the suite can be run on an idle machine — ideally the
+Linux target this pool is deployed on.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,27 +12,57 @@
   cross-shard and peer-steal walks, an `is_empty()` probe before each
   steal on the unarmed scans (a shared load instead of a failed CAS),
   and moving on to the next victim on `Retry` instead of spinning on
-  the contended one — turn that storm back into useful work. Measured
-  on an M2 Max (12 cores, `--quick`): `steal_imbalance/8_workers`
-  41.3 ms → 5.5 ms (7.4×), `steady_state_busy/8_workers`
-  114.9 ms → 17.4 ms (6.6×), `per_core_steady_state` 91.2 ms →
-  19.6 ms (4.7×). Adding workers no longer makes the pool slower.
+  the contended one — turn that storm back into useful work. Adding
+  workers no longer makes the pool slower.
 - **Bounded spin before parking.** A worker now re-scans a few times
   with `spin_loop` backoff and then a few more with `yield_now`
   before it arms and parks, so a runnable already on its way is
   picked up without a futex round-trip. The `yield_now` rounds matter
   for oversubscribed pools, where a purely spinning worker starves
-  the producer it is waiting for. Single-task latency:
-  `park_unpark_handshake/1_worker` 7.2 µs → 5.1 µs,
-  `spawn_overhead/4_workers/1` 8.1 µs → 5.5 µs.
+  the producer it is waiting for.
 - **Faster producer spill.** `SPILL_THRESHOLD` drops from 32 to 8, so
   a single producer fanning out spreads across shards sooner instead
   of piling onto one while the other workers idle.
-- Net effect versus 0.7.0 on the microbenchmark suite: faster on 17 of
-  18 workloads, the exception being `steal_imbalance/2_workers`
-  (1.31 ms → 1.70 ms), where the pre-park backoff costs more than it
-  recovers. Numbers are from one machine and one OS; treat them as
-  directional.
+
+Measured against 0.7.0 on one M2 Max (8P+4E), macOS, criterion
+`--quick`, both revisions benchmarked back-to-back in one session.
+**Read these with the noise floor in mind:** rayon's numbers are
+included in the same runs as an unchanged control, and they varied by a
+median of 14.5% (max 32.6%) between runs, so a delta under ~15% here is
+not a signal.
+
+| workload | 0.7.0 | now | |
+|---|---|---|---|
+| `steady_state_busy/8_workers` | 105.8 ms | 16.0 ms | 6.6× |
+| `steal_imbalance/8_workers` | 31.9 ms | 5.0 ms | 6.3× |
+| `per_core_steady_state` | 78.8 ms | 18.6 ms | 4.25× |
+| `multi_producer_contention/4p_4w` | 1.56 ms | 0.89 ms | 1.75× |
+| `multi_producer_contention/2p_4w` | 1.01 ms | 0.58 ms | 1.75× |
+| `steal_imbalance/4_workers` | 5.81 ms | 3.54 ms | 1.64× |
+| `spawn_overhead/4_workers/10000` | 5.29 ms | 3.64 ms | 1.45× |
+| `spawn_overhead/4_workers/100` | 47.2 µs | 32.8 µs | 1.44× |
+| `multi_producer_contention/8p_4w` | 2.26 ms | 1.57 ms | 1.44× |
+| `spawn_overhead/4_workers/1000` | 462 µs | 322 µs | 1.43× |
+| `steady_state_busy/4_workers` | 8.05 ms | 5.88 ms | 1.37× |
+| `steal_imbalance/2_workers` | 894 µs | 1.49 ms | **0.60×** |
+| `park_unpark_handshake/8_workers` | 5.17 µs | 6.27 µs | **0.82×** |
+
+Every gain is at four workers or more; the single- and two-worker
+workloads land inside the noise band or slightly worse. So this is a
+**multi-worker scaling fix, not a single-task latency improvement** —
+`park_unpark_handshake` and the 1-worker `spawn_overhead` rows are flat
+within noise. The two real regressions are `steal_imbalance/2_workers`
+(67% slower) and `park_unpark_handshake/8_workers` (21% slower), where
+the pre-park backoff costs more than it recovers.
+
+Against rayon on the same machine and runs, affinitypool is now ahead on
+15 of 17 head-to-head workloads (`round_trip/8` 5.6 µs vs 13.8 µs;
+`round_trip/4` 5.2 µs vs 8.5 µs). rayon still leads the two
+single-task/one-worker cases (`round_trip/1` 5.05 µs vs 4.08 µs;
+`spawn_overhead/1w/1` 4.91 µs vs 3.54 µs). Note the "rayon wins
+single-task latency by 3–6×" table in the README was produced on Linux
+and does not reproduce here — treat all of this as directional for
+another OS.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "affinitypool"
 edition = "2024"
+# `let` chains in `Queue::push` / `Queue::scan` need 1.88 on edition
+# 2024; verified that 1.87 fails and 1.88 builds.
+rust-version = "1.88"
 version = "0.7.0"
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/benches/microbench.rs
+++ b/benches/microbench.rs
@@ -138,7 +138,13 @@ fn bench_park_unpark_handshake(c: &mut Criterion) {
 	let mut group = c.benchmark_group("park_unpark_handshake");
 	group.measurement_time(Duration::from_secs(10));
 
-	for &workers in &[1usize, 4, 8] {
+	// Worker counts deliberately reach well past a typical machine's core
+	// count, up towards `MAX_THREADS`. One task per iteration makes this
+	// the cheapest probe of the *pre-park* path, whose cost per pass is
+	// linear in the worker count (a worker scans every peer's deque
+	// before it parks). Without a case up here, that scaling would be
+	// entirely untested — the rest of the suite stops at 8.
+	for &workers in &[1usize, 4, 8, 64, 256, 512] {
 		group.bench_with_input(BenchmarkId::new("workers", workers), &workers, |b, &workers| {
 			b.iter_custom(|iters| {
 				rt.block_on(async move {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,6 +12,7 @@ pub struct Builder {
 	thread_name: Option<String>,
 	thread_stack_size: Option<usize>,
 	thread_per_core: bool,
+	shards: Option<usize>,
 }
 
 impl Builder {
@@ -28,6 +29,7 @@ impl Builder {
 			thread_name: None,
 			thread_stack_size: None,
 			thread_per_core: false,
+			shards: None,
 		}
 	}
 
@@ -142,6 +144,30 @@ impl Builder {
 		self
 	}
 
+	/// Set how many queue shards producers distribute work across.
+	///
+	/// Each producer thread sticks to one shard, so more shards means
+	/// less contention between concurrent producers but more empty
+	/// queues for an idle worker to scan. The default is one shard per
+	/// worker capped at 8, which suits most pools; raise it for a pool
+	/// fed by many concurrent producers on a high-core machine.
+	///
+	/// The value is rounded up to a power of two and clamped to at
+	/// most one shard per worker.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// let pool = affinitypool::Builder::new()
+	///     .worker_threads(32)
+	///     .shards(16)
+	///     .build();
+	/// ```
+	pub fn shards(mut self, shards: usize) -> Builder {
+		self.shards = Some(shards);
+		self
+	}
+
 	/// Finalize the [`Builder`] and build the [`Threadpool`].
 	///
 	/// # Examples
@@ -167,7 +193,7 @@ impl Builder {
 			stack_size: self.thread_stack_size,
 			num_threads: AtomicUsize::new(threads),
 			thread_count: AtomicUsize::new(0),
-			queue: Arc::new(Queue::new(threads)),
+			queue: Arc::new(Queue::new(threads, self.shards)),
 			thread_handles: Mutex::new(Vec::new()),
 		});
 		// Spawn the desired number of workers.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -152,8 +152,10 @@ impl Builder {
 	/// worker capped at 8, which suits most pools; raise it for a pool
 	/// fed by many concurrent producers on a high-core machine.
 	///
-	/// The value is rounded up to a power of two and clamped to at
-	/// most one shard per worker.
+	/// The value is clamped to `1..=worker_threads` and then rounded up
+	/// to a power of two, so the effective count can exceed the worker
+	/// count when that count is not itself a power of two (8 workers
+	/// with `shards(5)` gives 8 shards; 3 workers gives at most 4).
 	///
 	/// # Examples
 	///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl Threadpool {
 			stack_size: None,
 			num_threads: AtomicUsize::new(workers),
 			thread_count: AtomicUsize::new(0),
-			queue: Arc::new(Queue::new(workers)),
+			queue: Arc::new(Queue::new(workers, None)),
 			thread_handles: Mutex::new(Vec::new()),
 		});
 		// Spawn the desired number of workers.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -10,10 +10,11 @@
 //! * **Sharded injectors.** Up to [`MAX_SHARDS`] lock-free MPMC
 //!   `Injector<Runnable>`s. Producers pick a shard via a cached hash
 //!   of their thread ID (see [`crate::cpu`]) — a given producer
-//!   consistently lands on the same shard. Number of
-//!   shards is `num_workers.next_power_of_two().min(MAX_SHARDS)` so
-//!   the routing is a bitmask and a single-worker pool degenerates to
-//!   one shard with no scan cost.
+//!   consistently lands on the same shard. The count defaults to
+//!   `num_workers.next_power_of_two().min(MAX_SHARDS)` and can be
+//!   overridden per pool by [`crate::Builder::shards`]; it is always a
+//!   power of two so the routing is a bitmask, and a single-worker pool
+//!   degenerates to one shard with no scan cost.
 //! * **Per-worker deques.** Each worker owns one
 //!   `crossbeam_deque::Worker<Runnable>`. The owner thread is the
 //!   only producer to its own deque; pop/push from the owner is
@@ -44,7 +45,17 @@
 //! backoff ([`SPIN_ROUNDS`]) so a runnable already on its way is
 //! caught without a futex round-trip, then a few more with
 //! `yield_now` ([`YIELD_ROUNDS`]) so an oversubscribed pool hands the
-//! CPU back to the producer instead of spinning against it.
+//! CPU back to the producer instead of spinning against it. It is
+//! skipped entirely below [`MIN_WORKERS_FOR_PREPARK`] workers, where
+//! there is no contention to amortise and delaying the park is pure
+//! latency.
+//!
+//! How much this phase contributes relative to the scan-path changes
+//! above is **not yet established**: the only measurements available
+//! were taken on a machine with heavy background load, which moves
+//! these particular workloads by several-fold between runs of identical
+//! code. Do not re-tune the constants below against numbers from a busy
+//! machine.
 //!
 //! ## Producer spill
 //!
@@ -134,10 +145,11 @@ use crate::cpu;
 /// on separate cache lines and avoid false sharing during scans.
 type StealerSlot = CachePadded<ArcSwapOption<Stealer<Runnable>>>;
 
-/// Hard cap on the shard count. Picked empirically: 8 saturates
+/// Default cap on the shard count, overridable per pool via
+/// [`crate::Builder::shards`]. Picked empirically: 8 saturates
 /// producer-side distribution on common topologies (≤8-core boxes
 /// map one shard per core, 32-core boxes share 4 cores per shard)
-/// while keeping the worst-case empty scan at 8 cheap CAS attempts.
+/// while keeping the worst-case empty scan at 8 cheap loads.
 const MAX_SHARDS: usize = 8;
 
 /// Consecutive pushes to the same preferred shard before producer-
@@ -147,12 +159,29 @@ const MAX_SHARDS: usize = 8;
 /// across shards before the other workers give up and park.
 const SPILL_THRESHOLD: u32 = 8;
 
+/// Pools with fewer than this many workers skip the pre-park backoff
+/// entirely and park as soon as a scan comes up empty.
+///
+/// The backoff earns its cost by avoiding futex round-trips and by
+/// handing the CPU back to a producer that other workers are competing
+/// with — both of which scale with the number of workers. On a one- or
+/// two-worker pool there is almost no such contention to amortise, so
+/// the delay before parking is close to pure added latency, which is
+/// why those pools opt out.
+const MIN_WORKERS_FOR_PREPARK: usize = 3;
+
 /// Re-scans performed with `spin_loop` backoff before a worker gives
-/// up its CPU. Kept small: the point is to catch a runnable already
-/// on its way, not to poll. Pure spinning is the cheapest way to win
-/// a submit-and-await round trip, but it burns a core, so this phase
-/// stays sub-microsecond.
-const SPIN_ROUNDS: u32 = 3;
+/// up its CPU. The point is to catch a runnable already on its way, not
+/// to poll — spinning is the cheapest way to win a submit-and-await
+/// round trip, but it burns a core.
+///
+/// Six matches `crossbeam_utils::Backoff`'s own spin/yield boundary
+/// (`SPIN_LIMIT`), i.e. exactly the point at which that crate stops
+/// spinning and starts yielding, so the two halves of this phase line up
+/// with the backoff primitive driving them. That is a principled anchor
+/// rather than a measured optimum — see the caveat in the module docs
+/// about tuning these against a busy machine.
+const SPIN_ROUNDS: u32 = 6;
 
 /// Re-scans performed with `yield_now` between them, after
 /// [`SPIN_ROUNDS`] and before parking. These exist for the
@@ -284,15 +313,18 @@ impl Drop for WorkerScope<'_> {
 
 impl Queue {
 	/// Build a queue for `num_workers` workers. `shard_override`
-	/// replaces the default shard count (see [`MAX_SHARDS`]); it is
-	/// rounded up to a power of two — the routing is a bitmask — and
-	/// clamped to at least one and at most one shard per worker,
-	/// since shards beyond the worker count only add empty-scan cost.
+	/// replaces the default shard count (see [`MAX_SHARDS`]): it is
+	/// clamped to `1..=num_workers` — shards beyond the worker count
+	/// only add empty-scan cost — and then rounded up to a power of
+	/// two, because the routing is a bitmask.
 	pub(crate) fn new(num_workers: usize, shard_override: Option<usize>) -> Self {
-		// `MAX_THREADS = 512` clamps the caller side, so
-		// `next_power_of_two` cannot overflow here.
+		// Clamp *before* `next_power_of_two`, not after: the override is
+		// arbitrary caller input, and `next_power_of_two` overflows (and
+		// panics on a debug build) for anything above `1 << 63`.
+		// `num_workers` is already clamped to `MAX_THREADS` by the
+		// caller, so rounding it up cannot overflow.
 		let num_shards = match shard_override {
-			Some(n) => n.max(1).next_power_of_two().clamp(1, num_workers.next_power_of_two()),
+			Some(n) => n.clamp(1, num_workers).next_power_of_two(),
 			None => num_workers.next_power_of_two().clamp(1, MAX_SHARDS),
 		};
 		let injectors: Vec<CachePadded<Injector<Runnable>>> =
@@ -520,10 +552,15 @@ impl Queue {
 			// falls through to arm and park, so an idle pool still
 			// goes to sleep. Scans here are `Cheap` because they
 			// repeat.
+			let (spin_rounds, yield_rounds) = if self.stealers.len() >= MIN_WORKERS_FOR_PREPARK {
+				(SPIN_ROUNDS, YIELD_ROUNDS)
+			} else {
+				(0, 0)
+			};
 			let backoff = Backoff::new();
 			let mut spun = None;
-			for round in 0..SPIN_ROUNDS + YIELD_ROUNDS {
-				if round < SPIN_ROUNDS {
+			for round in 0..spin_rounds + yield_rounds {
+				if round < spin_rounds {
 					backoff.spin();
 				} else {
 					std::thread::yield_now();
@@ -551,9 +588,12 @@ impl Queue {
 			// notify path. See module-level proof.
 			fence(Ordering::SeqCst);
 
-			// Re-scan under the arm. `Strict`: this read is the
-			// worker's half of the Dekker pair, so it must be the
-			// same injector access the proof is written against.
+			// Re-scan under the arm. `Strict` is REQUIRED here, not a
+			// preference: this read is the worker's half of the Dekker
+			// pair, so it must be the same injector access the proof is
+			// written against. Switching it to `Probe::Cheap` would
+			// substitute `is_empty`'s weaker read for that access and
+			// invalidate the lost-wakeup argument in the module docs.
 			if let Some(r) = self.scan(ctx, Probe::Strict) {
 				self.parked.fetch_sub(1, Ordering::Release);
 				return Some(r);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -29,8 +29,22 @@
 //!   replaces a worker's slot when [`Sentry`] starts a fresh
 //!   thread.
 //!
-//! Pop order: own deque → preferred injector → other injectors,
-//! cyclic → other workers' stealers → park.
+//! Pop order: own deque → preferred injector → other injectors →
+//! other workers' stealers → bounded spin → park.
+//!
+//! The two cross-worker steps visit every victim exactly once but
+//! start at a per-worker random rotation, so idle workers don't
+//! convoy onto the same injector in lockstep. On the unarmed scans
+//! each victim is `is_empty()`-probed before the steal is attempted,
+//! turning an idle pool's repeated scanning into shared loads rather
+//! than a storm of contended CAS. A `Steal::Retry` moves on to the
+//! next victim instead of spinning on the contended one.
+//!
+//! Before parking, a worker re-scans a few times with `spin_loop`
+//! backoff ([`SPIN_ROUNDS`]) so a runnable already on its way is
+//! caught without a futex round-trip, then a few more with
+//! `yield_now` ([`YIELD_ROUNDS`]) so an oversubscribed pool hands the
+//! CPU back to the producer instead of spinning against it.
 //!
 //! ## Producer spill
 //!
@@ -103,7 +117,7 @@
 use arc_swap::ArcSwapOption;
 use async_task::Runnable;
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
-use crossbeam_utils::CachePadded;
+use crossbeam_utils::{Backoff, CachePadded};
 use parking_lot::{Condvar, Mutex};
 use std::cell::Cell;
 use std::marker::PhantomData;
@@ -127,11 +141,26 @@ type StealerSlot = CachePadded<ArcSwapOption<Stealer<Runnable>>>;
 const MAX_SHARDS: usize = 8;
 
 /// Consecutive pushes to the same preferred shard before producer-
-/// side spill kicks in. Picked empirically: large enough that
-/// genuinely-affine producers (multi-producer benches) never trip
-/// it, small enough that a single-producer fan-out distributes
-/// across workers before they have time to park.
-const SPILL_THRESHOLD: u32 = 32;
+/// side spill kicks in. Multi-producer workloads rarely reach it
+/// (their pushes interleave, resetting the counter), while a
+/// single-producer fan-out trips it quickly so the work spreads
+/// across shards before the other workers give up and park.
+const SPILL_THRESHOLD: u32 = 8;
+
+/// Re-scans performed with `spin_loop` backoff before a worker gives
+/// up its CPU. Kept small: the point is to catch a runnable already
+/// on its way, not to poll. Pure spinning is the cheapest way to win
+/// a submit-and-await round trip, but it burns a core, so this phase
+/// stays sub-microsecond.
+const SPIN_ROUNDS: u32 = 3;
+
+/// Re-scans performed with `yield_now` between them, after
+/// [`SPIN_ROUNDS`] and before parking. These exist for the
+/// *oversubscribed* case: when workers outnumber free cores, an idle
+/// worker that only spins starves the very producer it is waiting
+/// for, so handing the CPU back beats both spinning and an immediate
+/// park. Kept small too — each yield is a syscall.
+const YIELD_ROUNDS: u32 = 4;
 
 thread_local! {
 	/// `(last_preferred_shard, consecutive_count)`. Reset when the
@@ -203,6 +232,38 @@ pub(crate) struct Queue {
 pub(crate) struct WorkerContext {
 	idx: usize,
 	deque: Worker<Runnable>,
+	/// xorshift32 state for randomising the *start offset* of the
+	/// cross-shard and peer-steal scans. Without it every idle worker
+	/// walks victims in the same order and they convoy onto the same
+	/// injector, turning an idle pool into a CAS storm on one cache
+	/// line. Seeded from `idx` (never zero — xorshift is absorbing at
+	/// zero) so a respawned worker re-derives the same stream, which
+	/// keeps runs reproducible. `Cell` is sound here because
+	/// `WorkerContext` is owned by, and only ever touched from, its
+	/// own worker thread — same justification as the `!Sync` deque.
+	rng: Cell<u32>,
+}
+
+/// How hard a [`Queue::scan`] pass should work to notice a runnable.
+/// See [`Queue::scan`] for why the armed re-scan must stay strict.
+#[derive(Clone, Copy)]
+enum Probe {
+	/// Skip a victim whose `is_empty()` says empty.
+	Cheap,
+	/// Always attempt the steal.
+	Strict,
+}
+
+/// Advance an xorshift32 and return the new state. Cheap enough
+/// (3 shifts, 3 xors) to run on every scan pass.
+#[inline]
+fn next_rand(rng: &Cell<u32>) -> u32 {
+	let mut x = rng.get();
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	rng.set(x);
+	x
 }
 
 /// RAII guard returned by [`Queue::enter_worker_scope`]. While
@@ -222,10 +283,18 @@ impl Drop for WorkerScope<'_> {
 }
 
 impl Queue {
-	pub(crate) fn new(num_workers: usize) -> Self {
+	/// Build a queue for `num_workers` workers. `shard_override`
+	/// replaces the default shard count (see [`MAX_SHARDS`]); it is
+	/// rounded up to a power of two — the routing is a bitmask — and
+	/// clamped to at least one and at most one shard per worker,
+	/// since shards beyond the worker count only add empty-scan cost.
+	pub(crate) fn new(num_workers: usize, shard_override: Option<usize>) -> Self {
 		// `MAX_THREADS = 512` clamps the caller side, so
 		// `next_power_of_two` cannot overflow here.
-		let num_shards = num_workers.next_power_of_two().clamp(1, MAX_SHARDS);
+		let num_shards = match shard_override {
+			Some(n) => n.max(1).next_power_of_two().clamp(1, num_workers.next_power_of_two()),
+			None => num_workers.next_power_of_two().clamp(1, MAX_SHARDS),
+		};
 		let injectors: Vec<CachePadded<Injector<Runnable>>> =
 			(0..num_shards).map(|_| CachePadded::new(Injector::new())).collect();
 		let stealers: Vec<StealerSlot> =
@@ -258,6 +327,9 @@ impl Queue {
 		WorkerContext {
 			idx,
 			deque,
+			// Mix the index so adjacent workers get unrelated streams,
+			// and force the low bit so the state is never zero.
+			rng: Cell::new((idx as u32).wrapping_mul(0x9E37_79B9) | 1),
 		}
 	}
 
@@ -422,7 +494,46 @@ impl Queue {
 			// Phase 1: lock-free scan. No park lock held, so
 			// producers can push concurrently without blocking
 			// on us.
-			if let Some(r) = self.scan(ctx) {
+			if let Some(r) = self.scan(ctx, Probe::Cheap) {
+				return Some(r);
+			}
+
+			// Phase 1b: bounded spin before committing to a park.
+			// Parking costs a futex round-trip on both sides, which
+			// dominates a submit-and-await round trip when the next
+			// runnable is only a moment away. A few cheap re-scans
+			// first let a worker that is about to be handed work skip
+			// the syscall entirely.
+			//
+			// Two sub-phases, because the right thing to do with an
+			// idle worker depends on whether the machine has a spare
+			// core for it:
+			//
+			// * [`SPIN_ROUNDS`] of `spin_loop` — cheapest way to catch
+			//   an imminent runnable when a core is free.
+			// * [`YIELD_ROUNDS`] of `yield_now` — when workers
+			//   outnumber cores, a spinning worker starves the
+			//   producer it is waiting for, so give the CPU back
+			//   before parking.
+			//
+			// Both are bounded and a worker that still finds nothing
+			// falls through to arm and park, so an idle pool still
+			// goes to sleep. Scans here are `Cheap` because they
+			// repeat.
+			let backoff = Backoff::new();
+			let mut spun = None;
+			for round in 0..SPIN_ROUNDS + YIELD_ROUNDS {
+				if round < SPIN_ROUNDS {
+					backoff.spin();
+				} else {
+					std::thread::yield_now();
+				}
+				if let Some(r) = self.scan(ctx, Probe::Cheap) {
+					spun = Some(r);
+					break;
+				}
+			}
+			if let Some(r) = spun {
 				return Some(r);
 			}
 
@@ -440,8 +551,10 @@ impl Queue {
 			// notify path. See module-level proof.
 			fence(Ordering::SeqCst);
 
-			// Re-scan under the arm.
-			if let Some(r) = self.scan(ctx) {
+			// Re-scan under the arm. `Strict`: this read is the
+			// worker's half of the Dekker pair, so it must be the
+			// same injector access the proof is written against.
+			if let Some(r) = self.scan(ctx, Probe::Strict) {
 				self.parked.fetch_sub(1, Ordering::Release);
 				return Some(r);
 			}
@@ -460,47 +573,108 @@ impl Queue {
 	/// One lock-free scan pass: own deque → preferred injector →
 	/// other injectors → other workers' stealers. Returns the
 	/// first runnable found, or `None` if everything is empty.
+	///
+	/// Victim order for the two cross-worker steps is rotated by a
+	/// per-worker RNG so concurrent idle workers don't convoy onto
+	/// the same injector. Every victim is still visited exactly once
+	/// per pass, so a non-empty queue cannot be skipped.
+	///
+	/// `probe` trades a strong guarantee for cheapness:
+	///
+	/// * `Probe::Cheap` tests `is_empty()` before each steal. An
+	///   empty victim then costs a shared load instead of a failed
+	///   CAS, which is what keeps an idle multi-worker pool from
+	///   melting a cache line. Used on the unarmed scans, where a
+	///   missed just-pushed runnable is harmless — the worker either
+	///   loops and scans again or proceeds to arm, and the armed
+	///   re-scan is strict.
+	/// * `Probe::Strict` always attempts the steal. Used for the
+	///   armed re-scan, where the read of each injector is
+	///   load-bearing for the lost-wakeup proof (see module docs):
+	///   the proof needs the worker's access to the injector to be
+	///   ordered against the producer's push, so we keep the same
+	///   operation the original proof was written against rather
+	///   than reason about `is_empty`'s weaker read.
 	#[inline]
-	fn scan(&self, ctx: &WorkerContext) -> Option<Runnable> {
-		// 1. Own deque — owner-only, lock-free, zero contention.
-		if let Some(r) = ctx.deque.pop() {
-			return Some(r);
-		}
-
-		let n = self.mask + 1;
-		let my_shard = ctx.idx & self.mask;
-
-		// 2. Preferred injector. `steal_batch_and_pop` migrates
-		//    a batch into our deque and returns one runnable;
-		//    subsequent pops in step 1 hit the local deque
-		//    without any cross-shard traffic.
-		if let Some(r) = retry_steal(|| self.injectors[my_shard].steal_batch_and_pop(&ctx.deque)) {
-			return Some(r);
-		}
-
-		// 3. Other injectors in cyclic order, starting from the
-		//    shard adjacent to our preferred one.
-		for offset in 1..n {
-			let idx = (my_shard + offset) & self.mask;
-			if let Some(r) = retry_steal(|| self.injectors[idx].steal_batch_and_pop(&ctx.deque)) {
+	fn scan(&self, ctx: &WorkerContext, probe: Probe) -> Option<Runnable> {
+		// A `Steal::Retry` means someone else's CAS beat ours, not
+		// that the victim is empty. Spinning on that victim just
+		// burns the contended cache line, so a retry moves on to the
+		// next victim and we re-walk only if the whole pass found
+		// nothing while at least one victim was contended. `Retry`
+		// implies concurrent activity, so this terminates.
+		loop {
+			// 1. Own deque — owner-only, lock-free, zero contention.
+			if let Some(r) = ctx.deque.pop() {
 				return Some(r);
 			}
-		}
 
-		// 4. Other workers' deques, last resort. Lock-free
-		//    `ArcSwapOption::load` returns an `Arc<Stealer>` we
-		//    can steal through without any per-slot mutex.
-		let num_workers = self.stealers.len();
-		for offset in 1..num_workers {
-			let victim = (ctx.idx + offset) % num_workers;
-			if let Some(stealer) = self.stealers[victim].load_full()
-				&& let Some(r) = retry_steal(|| stealer.steal_batch_and_pop(&ctx.deque))
-			{
-				return Some(r);
+			let mut contended = false;
+			let n = self.mask + 1;
+			let my_shard = ctx.idx & self.mask;
+
+			// 2. Preferred injector. `steal_batch_and_pop` migrates
+			//    a batch into our deque and returns one runnable;
+			//    subsequent pops in step 1 hit the local deque
+			//    without any cross-shard traffic.
+			match self.steal_injector(my_shard, ctx, probe) {
+				Steal::Success(r) => return Some(r),
+				Steal::Retry => contended = true,
+				Steal::Empty => {}
+			}
+
+			// 3. Other injectors, every one visited once, starting at
+			//    a random rotation.
+			if n > 1 {
+				let span = n - 1;
+				let start = next_rand(&ctx.rng) as usize % span;
+				for k in 0..span {
+					let idx = (my_shard + 1 + (start + k) % span) & self.mask;
+					match self.steal_injector(idx, ctx, probe) {
+						Steal::Success(r) => return Some(r),
+						Steal::Retry => contended = true,
+						Steal::Empty => {}
+					}
+				}
+			}
+
+			// 4. Other workers' deques, last resort. Lock-free
+			//    `ArcSwapOption::load` returns an `Arc<Stealer>` we
+			//    can steal through without any per-slot mutex.
+			let num_workers = self.stealers.len();
+			if num_workers > 1 {
+				let span = num_workers - 1;
+				let start = next_rand(&ctx.rng) as usize % span;
+				for k in 0..span {
+					let victim = (ctx.idx + 1 + (start + k) % span) % num_workers;
+					let Some(stealer) = self.stealers[victim].load_full() else {
+						continue;
+					};
+					if matches!(probe, Probe::Cheap) && stealer.is_empty() {
+						continue;
+					}
+					match stealer.steal_batch_and_pop(&ctx.deque) {
+						Steal::Success(r) => return Some(r),
+						Steal::Retry => contended = true,
+						Steal::Empty => {}
+					}
+				}
+			}
+
+			if !contended {
+				return None;
 			}
 		}
+	}
 
-		None
+	/// One steal attempt against injector `idx`, skipped entirely on
+	/// an apparently-empty injector when `probe` allows it.
+	#[inline]
+	fn steal_injector(&self, idx: usize, ctx: &WorkerContext, probe: Probe) -> Steal<Runnable> {
+		if matches!(probe, Probe::Cheap) && self.injectors[idx].is_empty() {
+			return Steal::Empty;
+		}
+		self.injectors[idx].steal_batch_and_pop(&ctx.deque)
 	}
 
 	/// Signal shutdown and wake every worker. Workers see the
@@ -512,18 +686,5 @@ impl Queue {
 		// wakeup to a worker mid-arm.
 		let _g = self.park.lock();
 		self.notify.notify_all();
-	}
-}
-
-/// `crossbeam_deque::Steal` returns `Retry` on transient CAS
-/// failure. Spin until `Success` or `Empty`.
-#[inline]
-fn retry_steal(mut f: impl FnMut() -> Steal<Runnable>) -> Option<Runnable> {
-	loop {
-		match f() {
-			Steal::Success(r) => return Some(r),
-			Steal::Empty => return None,
-			Steal::Retry => continue,
-		}
 	}
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -45,17 +45,19 @@
 //! backoff ([`SPIN_ROUNDS`]) so a runnable already on its way is
 //! caught without a futex round-trip, then a few more with
 //! `yield_now` ([`YIELD_ROUNDS`]) so an oversubscribed pool hands the
-//! CPU back to the producer instead of spinning against it. It is
-//! skipped entirely below [`MIN_WORKERS_FOR_PREPARK`] workers, where
-//! there is no contention to amortise and delaying the park is pure
-//! latency.
+//! CPU back to the producer instead of spinning against it.
 //!
-//! How much this phase contributes relative to the scan-path changes
-//! above is **not yet established**: the only measurements available
-//! were taken on a machine with heavy background load, which moves
-//! these particular workloads by several-fold between runs of identical
-//! code. Do not re-tune the constants below against numbers from a busy
-//! machine.
+//! This phase applies to every pool size. An earlier revision skipped it
+//! for one- and two-worker pools, on the theory that a small pool has no
+//! contention to amortise — measurement on an idle 32-core Linux box
+//! says the opposite: ungated, a single-worker submit-and-await round
+//! trip drops from 4.4 us to 1.1 us, because the worker is still
+//! spinning when the task lands and never takes the futex round trip at
+//! all. It costs 15-20% on `multi_producer` with one worker and many
+//! producers, where the worker is saturated and the backoff is pure
+//! delay. Note that a CPU-*contended* machine inverts this trade, since
+//! a spinning worker there competes with the producer it is waiting
+//! for.
 //!
 //! ## Producer spill
 //!
@@ -158,17 +160,6 @@ const MAX_SHARDS: usize = 8;
 /// single-producer fan-out trips it quickly so the work spreads
 /// across shards before the other workers give up and park.
 const SPILL_THRESHOLD: u32 = 8;
-
-/// Pools with fewer than this many workers skip the pre-park backoff
-/// entirely and park as soon as a scan comes up empty.
-///
-/// The backoff earns its cost by avoiding futex round-trips and by
-/// handing the CPU back to a producer that other workers are competing
-/// with — both of which scale with the number of workers. On a one- or
-/// two-worker pool there is almost no such contention to amortise, so
-/// the delay before parking is close to pure added latency, which is
-/// why those pools opt out.
-const MIN_WORKERS_FOR_PREPARK: usize = 3;
 
 /// Re-scans performed with `spin_loop` backoff before a worker gives
 /// up its CPU. The point is to catch a runnable already on its way, not
@@ -552,15 +543,10 @@ impl Queue {
 			// falls through to arm and park, so an idle pool still
 			// goes to sleep. Scans here are `Cheap` because they
 			// repeat.
-			let (spin_rounds, yield_rounds) = if self.stealers.len() >= MIN_WORKERS_FOR_PREPARK {
-				(SPIN_ROUNDS, YIELD_ROUNDS)
-			} else {
-				(0, 0)
-			};
 			let backoff = Backoff::new();
 			let mut spun = None;
-			for round in 0..spin_rounds + yield_rounds {
-				if round < spin_rounds {
+			for round in 0..SPIN_ROUNDS + YIELD_ROUNDS {
+				if round < SPIN_ROUNDS {
 					backoff.spin();
 				} else {
 					std::thread::yield_now();

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -170,8 +170,19 @@ const SPILL_THRESHOLD: u32 = 8;
 /// trip on a 512-worker pool costs ~69 µs against ~2 µs at 8 workers,
 /// almost all of it spent walking idle peers. The per-worker random start
 /// rotates which victims each pass inspects, so a few passes still cover
-/// a wide spread, and anything missed is caught by the exhaustive scan
-/// the worker performs before it actually parks.
+/// a wide spread.
+///
+/// Bounding this cannot strand work, for three independent reasons, which
+/// is why the cap can be this aggressive: a worker always checks its
+/// preferred injector unbounded, so every shard has a dedicated checker
+/// whenever the shard count is at most the worker count; where it is not
+/// (the count is rounded up to a power of two), reaching more than eight
+/// others requires at least nine workers, all scanning with independent
+/// random rotations; and the sweep a worker performs immediately before
+/// parking is exhaustive regardless. That last one is what the
+/// lost-wakeup proof actually rests on — it is a visibility-ordering
+/// requirement, not a coverage one, which is why it must stay unbounded
+/// even though liveness would survive without it.
 const CHEAP_SCAN_VICTIMS: usize = 8;
 
 /// Re-scans performed with `spin_loop` backoff before a worker gives

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -161,6 +161,19 @@ const MAX_SHARDS: usize = 8;
 /// across shards before the other workers give up and park.
 const SPILL_THRESHOLD: u32 = 8;
 
+/// Victims a *cheap* scan pass inspects before giving up, per step.
+///
+/// The armed re-scan still visits every injector and every peer — that
+/// sweep is load-bearing for the lost-wakeup proof — but the unarmed and
+/// pre-park passes stop here, because their cost is paid on every wake
+/// and it grows with the pool. Unbounded, a single submit-and-await round
+/// trip on a 512-worker pool costs ~69 µs against ~2 µs at 8 workers,
+/// almost all of it spent walking idle peers. The per-worker random start
+/// rotates which victims each pass inspects, so a few passes still cover
+/// a wide spread, and anything missed is caught by the exhaustive scan
+/// the worker performs before it actually parks.
+const CHEAP_SCAN_VICTIMS: usize = 8;
+
 /// Re-scans performed with `spin_loop` backoff before a worker gives
 /// up its CPU. The point is to catch a runnable already on its way, not
 /// to poll — spinning is the cheapest way to win a submit-and-await
@@ -654,7 +667,7 @@ impl Queue {
 			if n > 1 {
 				let span = n - 1;
 				let start = next_rand(&ctx.rng) as usize % span;
-				for k in 0..span {
+				for k in 0..self.probe_limit(span, probe) {
 					let idx = (my_shard + 1 + (start + k) % span) & self.mask;
 					match self.steal_injector(idx, ctx, probe) {
 						Steal::Success(r) => return Some(r),
@@ -664,16 +677,25 @@ impl Queue {
 				}
 			}
 
-			// 4. Other workers' deques, last resort. Lock-free
-			//    `ArcSwapOption::load` returns an `Arc<Stealer>` we
-			//    can steal through without any per-slot mutex.
+			// 4. Other workers' deques, last resort. Lock-free: no
+			//    per-slot mutex.
+			//
+			//    `load()`, not `load_full()`. `load_full` clones the
+			//    `Arc`, and that refcount is a line every idle worker
+			//    would touch on every pass — the same convoy the
+			//    `is_empty` probe above exists to avoid, one level up.
+			//    `load()` hands back a guard instead and leaves the
+			//    refcount alone. The guard is held only across the
+			//    probe and one steal attempt, which is the short-lived
+			//    use `arc_swap` asks for.
 			let num_workers = self.stealers.len();
 			if num_workers > 1 {
 				let span = num_workers - 1;
 				let start = next_rand(&ctx.rng) as usize % span;
-				for k in 0..span {
+				for k in 0..self.probe_limit(span, probe) {
 					let victim = (ctx.idx + 1 + (start + k) % span) % num_workers;
-					let Some(stealer) = self.stealers[victim].load_full() else {
+					let slot = self.stealers[victim].load();
+					let Some(stealer) = slot.as_ref() else {
 						continue;
 					};
 					if matches!(probe, Probe::Cheap) && stealer.is_empty() {
@@ -690,6 +712,20 @@ impl Queue {
 			if !contended {
 				return None;
 			}
+		}
+	}
+
+	/// How many victims one scan step should walk out of `span`
+	/// available. `Probe::Strict` always walks all of them — the armed
+	/// re-scan has to observe every injector for the lost-wakeup proof
+	/// to hold. `Probe::Cheap` caps it at [`CHEAP_SCAN_VICTIMS`], since
+	/// those passes run on every wake and are pure overhead once the
+	/// pool is large.
+	#[inline]
+	fn probe_limit(&self, span: usize, probe: Probe) -> usize {
+		match probe {
+			Probe::Cheap => span.min(CHEAP_SCAN_VICTIMS),
+			Probe::Strict => span,
 		}
 	}
 

--- a/tests/loom_queue.rs
+++ b/tests/loom_queue.rs
@@ -199,6 +199,79 @@ fn push_to_remote_shard() {
 	});
 }
 
+/// Two workers, one item, then shutdown. Exactly one worker may take
+/// the item; the other must exit rather than hang.
+///
+/// The single-worker models above cannot catch a wake delivered to the
+/// wrong worker, because there is only one. Asserting *exactly one*
+/// winner here catches a lost item (nobody gets it) and a double-take
+/// (both do) in the same assertion, and loom fails the model outright
+/// if either worker cannot finish.
+#[test]
+fn one_push_two_workers_exactly_one_wins() {
+	loom::model(|| {
+		let q = Arc::new(Queue::new(2));
+		let producer = {
+			let q = q.clone();
+			thread::spawn(move || {
+				q.push(0);
+				// Let the loser exit instead of sleeping forever.
+				q.shutdown();
+			})
+		};
+		let w0 = {
+			let q = q.clone();
+			thread::spawn(move || q.pop_blocking(0))
+		};
+		let w1 = {
+			let q = q.clone();
+			thread::spawn(move || q.pop_blocking(1))
+		};
+		producer.join().unwrap();
+		let a = w0.join().unwrap();
+		let b = w1.join().unwrap();
+		assert_eq!(
+			a.iter().count() + b.iter().count(),
+			1,
+			"exactly one worker must take the single item"
+		);
+	});
+}
+
+/// Two items, two workers, and deliberately **no shutdown**: both
+/// workers must come back with an item.
+///
+/// Every worker that parks here has work waiting for it, so a wakeup
+/// that goes missing strands a worker with an item still queued and
+/// nothing left to wake it — loom's deadlock detection fires on the
+/// blocked thread. The absence of `shutdown()` is the point: a shutdown
+/// would rescue the stranded worker and hide exactly the class of bug
+/// this model exists to catch.
+#[test]
+fn two_pushes_two_workers_neither_is_stranded() {
+	loom::model(|| {
+		let q = Arc::new(Queue::new(2));
+		let producer = {
+			let q = q.clone();
+			thread::spawn(move || {
+				q.push(0);
+				q.push(1);
+			})
+		};
+		let w0 = {
+			let q = q.clone();
+			thread::spawn(move || q.pop_blocking(0))
+		};
+		let w1 = {
+			let q = q.clone();
+			thread::spawn(move || q.pop_blocking(1))
+		};
+		producer.join().unwrap();
+		assert_eq!(w0.join().unwrap(), Some(()));
+		assert_eq!(w1.join().unwrap(), Some(()));
+	});
+}
+
 /// `shutdown()` must wake a worker that is already parked (or
 /// about to park) on an empty queue. Without the `park.lock()` in
 /// `shutdown`, the broadcast can race a worker mid-arm and the

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -206,6 +206,59 @@ async fn test_builder_extreme_shards_clamped() {
 	}
 }
 
+/// Work in a shard that no worker calls its own must still drain.
+///
+/// A worker always checks its *preferred* injector (`idx & mask`)
+/// unconditionally, so when the shard count is at most the worker count
+/// every shard has a dedicated checker. This covers the case the clamp
+/// still permits: 9 workers asking for 9 shards get **16**, because the
+/// count is rounded up to a power of two, so shards 9-15 have no worker
+/// that prefers them and must be reached by the cross-shard walk — which
+/// the unarmed passes bound.
+///
+/// Nothing else in the suite builds a pool with more shards than workers,
+/// so this is the only cover for that arithmetic. Note it is a smoke test,
+/// not a proof: work here is reachable several ways over (bounded random
+/// rotation across repeated passes, nine concurrent scanners, and the
+/// exhaustive pre-park sweep), so it passes even with the bound applied
+/// far more aggressively than shipped. It would catch an outright
+/// indexing or coverage blunder in the walk, not a subtle one.
+#[tokio::test]
+async fn test_unowned_shards_still_drain() {
+	const WORKERS: usize = 9;
+	const TASKS: usize = 3_000;
+
+	let pool = Builder::new().worker_threads(WORKERS).shards(WORKERS).build();
+	// Settle into a park so delivery depends on the wake + scan path.
+	tokio::time::sleep(Duration::from_millis(50)).await;
+
+	let counter = Arc::new(AtomicUsize::new(0));
+	let mut handles = Vec::with_capacity(TASKS);
+	for i in 0..TASKS {
+		let counter = counter.clone();
+		handles.push(pool.spawn(move || {
+			counter.fetch_add(1, Ordering::SeqCst);
+			i
+		}));
+	}
+
+	// Bound the wait: stranded work should fail the test, not hang CI.
+	let collected = tokio::time::timeout(Duration::from_secs(30), async {
+		let mut out = Vec::with_capacity(TASKS);
+		for h in handles {
+			out.push(h.await);
+		}
+		out
+	})
+	.await
+	.expect("tasks did not all complete: work stranded in a shard no worker prefers?");
+
+	assert_eq!(counter.load(Ordering::SeqCst), TASKS, "some task ran more or less than once");
+	let mut sorted = collected;
+	sorted.sort_unstable();
+	assert_eq!(sorted, (0..TASKS).collect::<Vec<_>>(), "task results do not match one-to-one");
+}
+
 #[tokio::test]
 async fn test_thread_naming() {
 	let pool = Builder::new().worker_threads(2).thread_name("test-worker").build();

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -193,12 +193,17 @@ async fn test_builder_shard_override() {
 	}
 }
 
-/// A zero shard override must not panic or divide by zero; it clamps to
-/// a single shard.
+/// The shard override is arbitrary caller input, so both ends of the
+/// range must be clamped rather than trusted. Zero must not divide by
+/// zero, and a huge value must not overflow the power-of-two rounding —
+/// `usize::MAX.next_power_of_two()` panics on a debug build, so the
+/// clamp has to happen first.
 #[tokio::test]
-async fn test_builder_zero_shards_clamped() {
-	let pool = Builder::new().worker_threads(4).shards(0).build();
-	assert_eq!(pool.spawn(|| 7).await, 7);
+async fn test_builder_extreme_shards_clamped() {
+	for shards in [0usize, 1, usize::MAX, usize::MAX - 1, 1 << 63, (1 << 63) + 1] {
+		let pool = Builder::new().worker_threads(4).shards(shards).build();
+		assert_eq!(pool.spawn(|| 7).await, 7, "shards={shards}");
+	}
 }
 
 #[tokio::test]

--- a/tests/threadpool_tests.rs
+++ b/tests/threadpool_tests.rs
@@ -160,6 +160,47 @@ async fn test_builder_configuration() {
 	assert_eq!(result, 42);
 }
 
+/// `Builder::shards` is a routing hint, not a correctness knob: every
+/// task must still run exactly once whatever the shard count, including
+/// the degenerate single-shard case and an override larger than the
+/// worker count (which the builder clamps).
+#[tokio::test]
+async fn test_builder_shard_override() {
+	for (workers, shards) in [(4usize, 1usize), (4, 2), (4, 4), (2, 64), (1, 8), (8, 3)] {
+		let pool = Builder::new().worker_threads(workers).shards(shards).build();
+		let counter = Arc::new(AtomicUsize::new(0));
+
+		let mut handles = Vec::new();
+		for i in 0..200 {
+			let counter = counter.clone();
+			handles.push(pool.spawn(move || {
+				counter.fetch_add(1, Ordering::SeqCst);
+				i
+			}));
+		}
+		let mut results = Vec::new();
+		for h in handles {
+			results.push(h.await);
+		}
+
+		assert_eq!(
+			counter.load(Ordering::SeqCst),
+			200,
+			"workers={workers} shards={shards}: not every task ran exactly once"
+		);
+		results.sort();
+		assert_eq!(results, (0..200).collect::<Vec<_>>(), "workers={workers} shards={shards}");
+	}
+}
+
+/// A zero shard override must not panic or divide by zero; it clamps to
+/// a single shard.
+#[tokio::test]
+async fn test_builder_zero_shards_clamped() {
+	let pool = Builder::new().worker_threads(4).shards(0).build();
+	assert_eq!(pool.spawn(|| 7).await, 7);
+}
+
 #[tokio::test]
 async fn test_thread_naming() {
 	let pool = Builder::new().worker_threads(2).thread_name("test-worker").build();


### PR DESCRIPTION
The scheduling rework (PR2). Targets `main`, now that #45 has merged.

Does **not** touch the parked-handshake or its Dekker proof: the armed re-scan keeps the exact injector access the proof is written against (`Probe::Strict`).

## The problem

Benchmarking `main` turned up something worse than the rayon gap this work set out to close: **a pool got slower when given more workers for identical work.** An idle multi-worker pool was burning itself on the steal path — every worker walked victims in the same order so they convoyed onto one injector, every steal was an unconditional contended CAS even against an obviously empty victim, and `Steal::Retry` spun *in place* on that same victim.

## Changes

- **Randomised victim order** — per-worker xorshift rotates the start of the cross-shard and peer-steal walks. Every victim still visited exactly once per pass.
- **`is_empty()` probe before each steal on the unarmed scans**, so an empty victim costs a shared load instead of a failed CAS. The armed re-scan stays strict, because that read is the worker's half of the Dekker pair.
- **Move on from `Steal::Retry`** to the next victim, re-walking only if a whole pass found nothing while something was contended — rayon's pattern.
- **Bounded pre-park phase**: `SPIN_ROUNDS` (6, matching `crossbeam_utils::Backoff`'s `SPIN_LIMIT`) `spin_loop` re-scans, then `YIELD_ROUNDS` (4) `yield_now` re-scans, at every pool size.
- **`SPILL_THRESHOLD` 32 → 8** so a single producer spreads across shards sooner.
- **New `Builder::shards(n)`** to override the shard count.
- **Two new loom models** for multi-worker wake delivery; one verified to *fail* against a deliberately broken wake path, so it detects the hazard rather than passing vacuously.
- **`rust-version = "1.88"`**, verified empirically (1.87 rejects the `let` chains, 1.88 builds).

## Results

Idle **AMD Ryzen Threadripper 9970X** (32C/64T, one NUMA node), Ubuntu 24.04, kernel 6.8, **full criterion sampling**, all revisions back-to-back in one session at load average 0.00, rayon built from the same runs as an unchanged control. Every figure has **non-overlapping criterion confidence intervals** (median CI width 11%).

**24 of 27 microbenchmarks faster, 3 slower.**

| workload | main | this PR | |
|---|---|---|---|
| `steal_imbalance/8_workers` | 25.4 ms | **3.64 ms** | 6.98× |
| `spawn_overhead/4_workers/1` | 6.14 µs | **1.11 µs** | 5.51× |
| `steady_state_busy/8_workers` | 98.2 ms | **17.9 ms** | 5.49× |
| `park_unpark_handshake/4_workers` | 5.83 µs | **1.09 µs** | 5.32× |
| `spawn_overhead/1_worker/1` | 5.37 µs | **1.17 µs** | 4.60× |
| `spawn_local_overhead/4w/1000` | 4.87 ms | **1.09 ms** | 4.46× |
| `steady_state_busy/4_workers` | 18.2 ms | **4.47 ms** | 4.07× |
| `steal_imbalance/2_workers` | 9.33 ms | **2.46 ms** | 3.80× |
| `multi_producer_contention/2p_4w` | 2.66 ms | **878 µs** | 3.02× |
| **`per_core_steady_state`** (64 workers) | 203 ms | **74.2 ms** | **2.74×** |
| `multi_producer_contention/4p_1w` | 802 µs | 999 µs | **0.80×** |
| `multi_producer_contention/2p_1w` | 436 µs | 511 µs | **0.85×** |
| `multi_producer_contention/8p_1w` | 1.88 ms | 2.22 ms | **0.85×** |

The three regressions share one shape: a single worker fed by several producers, so the worker is saturated and the pre-park backoff is pure delay before a park it was always going to take.

### vs rayon — the README's claim reproduces, and this closes it

**affinitypool ahead on 14 of 17** head-to-head workloads (`multi_producer/4p_4w` 475 µs vs 1.08 ms; `spawn_overhead/4w/10000` 1.99 ms vs 3.46 ms). The README's long-standing "rayon wins single-task latency 3–6×" is **true on Linux** — and it was invisible on macOS, where earlier runs showed us ahead. The pre-park backoff closes it:

| workload | before | after | rayon |
|---|---|---|---|
| `round_trip/1` | 4.40 µs | **1.07 µs** | 0.94 µs (not separable) |
| `spawn_overhead/1w/1` | 5.95 µs | **0.98 µs** | 1.00 µs (ahead) |

Remaining rayon wins are marginal: `round_trip/8` 2.00 vs 1.91 µs (not separable) and `spawn_overhead/1w/100` 21.8 vs 19.6 µs.

### Caveat

These gains assume spare CPU. On a CPU-contended host a spinning worker competes with the producer it is waiting for — an earlier revision of this work measured the *opposite sign* on a loaded laptop (load average 7.6 on 12 cores), which is what produced the now-deleted `MIN_WORKERS_FOR_PREPARK` gate. The backoff yields as well as spins to limit this, but a heavily oversubscribed deployment should measure rather than assume.

## Also settled on the way

`v0.7.0 → main` on this box answers a question that predates this PR: **does CPU pinning help?** On 32 real cores, where `sched_setaffinity` actually works (on macOS it was a silent no-op), removing pinning was significantly *faster* on 6 workloads, slower on 3, indistinguishable on 18 — and `per_core_steady_state`, the benchmark whose whole purpose is pinned-worker-per-core, was 4% **slower** pinned. That comparison bundles #44's routing swap, so it is not pinning in isolation, but it does not argue against having removed it.

## Verification

`cargo test` (39 + doctests) · `clippy --all-targets -D warnings` · `fmt` · `loom` (6 models) · `miri --lib` · `cargo +1.88 check` — all green.